### PR TITLE
feat: add rtvi vision support

### DIFF
--- a/src/cmd/bots/base.py
+++ b/src/cmd/bots/base.py
@@ -122,7 +122,6 @@ class DailyRoomBot(IBot):
 
     def get_llm_processor(self) -> LLMProcessor:
         if self._bot_config.llm and self._bot_config.llm.tag \
-                and self._bot_config.llm.tag != "openai_llm_processor" \
                 and "vision" in self._bot_config.llm.tag:
             # engine llm processor(just support vision model, other TODO):
             # (llm_llamacpp, llm_personalai_proxy, llm_transformers etc..)

--- a/src/cmd/bots/base.py
+++ b/src/cmd/bots/base.py
@@ -5,6 +5,7 @@ import uuid
 
 from apipeline.frames.control_frames import EndFrame
 
+from src.processors.vision.vision_processor import MockVisionProcessor
 from src.processors.speech.asr.base import ASRProcessorBase
 from src.processors.llm.base import LLMProcessor
 from src.processors.speech.tts.base import TTSProcessorBase
@@ -127,10 +128,13 @@ class DailyRoomBot(IBot):
             # (llm_llamacpp, llm_personalai_proxy, llm_transformers etc..)
             from src.processors.vision.vision_processor import VisionProcessor
             logging.debug(f"init engine llm processor tag: {self._bot_config.llm.tag}")
-            session = Session(**SessionCtx(uuid.uuid4()).__dict__)
-            llm = LLMEnvInit.initLLMEngine(
-                self._bot_config.llm.tag, self._bot_config.llm.args)
-            llm_processor = VisionProcessor(llm, session)
+            if "mock" in self._bot_config.llm.tag:
+                llm_processor = MockVisionProcessor()
+            else:
+                session = Session(**SessionCtx(uuid.uuid4()).__dict__)
+                llm = LLMEnvInit.initLLMEngine(
+                    self._bot_config.llm.tag, self._bot_config.llm.args)
+                llm_processor = VisionProcessor(llm, session)
         else:
             from src.processors.llm.openai_llm_processor import OpenAILLMProcessor
             # default use openai llm processor

--- a/src/cmd/bots/base.py
+++ b/src/cmd/bots/base.py
@@ -162,7 +162,8 @@ class DailyRoomBot(IBot):
                 from src.processors.speech.tts.tts_processor import TTSProcessor
                 tts = TTSEnvInit.getEngine(
                     self._bot_config.tts.tag, **self._bot_config.tts.args)
-                self._bot_config.tts = TTSConfig(tag=tts.SELECTED_TAG, args=tts.get_args_dict())
+                self._bot_config.tts.tag = tts.SELECTED_TAG,
+                self._bot_config.tts.args = tts.get_args_dict()
                 tts_processor = TTSProcessor(tts=tts, session=self.session)
         else:
             # default tts engine processor

--- a/src/cmd/bots/main.py
+++ b/src/cmd/bots/main.py
@@ -40,11 +40,6 @@ if __name__ == "__main__":
     bot_info = RunBotInfo(**bot_config)
     logging.info(f"bot_config:{bot_config}")
 
-    if import_bots(bot_info.chat_bot_name) is False:
-        detail = f"un import bot: {bot_info.chat_bot_name}"
-        logging.error(detail)
-        exit()
-
     room_url = bot_info.room_url
     if len(args.u) > 0:
         bot_info.room_url = args.u

--- a/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
+++ b/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
@@ -435,12 +435,9 @@ class DailyRTVIGeneralBot(DailyRoomBot):
                 and self._bot_config.llm \
                 and self._bot_config.llm.tag \
                 and "vision" in self._bot_config.llm.tag:
+            hi = f"[HI_TEXT] Hello, welcome to use Vision Bot, I am your virtual assistant. u can ask me with video. [/HI_TEXT]"
             match self._bot_config.tts.language:
                 case "zh":
-                    await self.tts_processor.say("你好，欢迎使用 Vision Bot. 我是一名虚拟助手，可以结合视频进行提问。")
-                case "en":
-                    await self.tts_processor.say("Hello, welcome to use Vision Bot, I am your virtual assistant. u can ask me with video.")
-                case _:
-                    await self.tts_processor.say("Hello, welcome to use Vision Bot, I am your virtual assistant. u can ask me with video.")
-
+                    hi = f"[HI_TEXT] 你好，欢迎使用 Vision Bot. 我是一名虚拟助手，可以结合视频进行提问。[/HI_TEXT]"
+            await self.task.queue_frame(TextFrame(text=hi))
         logging.info("First participant joined")

--- a/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
+++ b/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
@@ -434,10 +434,10 @@ class DailyRTVIGeneralBot(DailyRoomBot):
                 and "vision" in self._bot_config.llm.tag:
             match self._bot_config.tts.language:
                 case "zh":
-                    await self.tts_processor.say("你好，欢迎使用 Vision Bot. 我是一名虚拟助手，可以结合视频进行提问")
+                    await self.tts_processor.say("你好，欢迎使用 Vision Bot. 我是一名虚拟助手，可以结合视频进行提问。")
                 case "en":
-                    await self.tts_processor.say("Hello, welcome to use Vision Bot, I am your virtual assistant. u can ask me with video")
+                    await self.tts_processor.say("Hello, welcome to use Vision Bot, I am your virtual assistant. u can ask me with video.")
                 case _:
-                    await self.tts_processor.say("Hello, welcome to use Vision Bot, I am your virtual assistant. u can ask me with video")
+                    await self.tts_processor.say("Hello, welcome to use Vision Bot, I am your virtual assistant. u can ask me with video.")
 
         logging.info("First participant joined")

--- a/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
+++ b/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
@@ -416,9 +416,12 @@ class DailyRTVIGeneralBot(DailyRoomBot):
     async def on_first_participant_joined(self, transport: DailyTransport, participant):
         if self.daily_params.transcription_enabled:
             transport.capture_participant_transcription(participant["id"])
-        if self.daily_params.camera_out_enabled:
+        if self._bot_config.llm \
+                and self._bot_config.llm.tag \
+                and "vision" in self._bot_config.llm.tag:
             transport.capture_participant_video(participant["id"], framerate=0)
             self.image_requester and self.image_requester.set_participant_id(participant["id"])
+
         # joined use tts say "hello" to introduce with llm generate
         if self._bot_config.tts \
                 and self._bot_config.llm \

--- a/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
+++ b/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
@@ -350,13 +350,14 @@ class DailyRTVIGeneralBot(DailyRoomBot):
                         processors.append(rtvi)
                     case "llm":
                         if self._bot_config.llm:
-                            processors.append(llm_user_ctx_aggr)
                             if self._bot_config.llm.tag and \
                                     "vision" in self._bot_config.llm.tag:
                                 self.image_requester = UserImageRequestProcessor()
                                 processors.append(self.image_requester)
                                 vision_aggregator = VisionImageFrameAggregator()
                                 processors.append(vision_aggregator)
+                            else:
+                                processors.append(llm_user_ctx_aggr)
                         self.llm_processor = self.get_llm_processor()
                         processors.append(self.llm_processor)
                     case "tts":
@@ -384,7 +385,11 @@ class DailyRTVIGeneralBot(DailyRoomBot):
         processors.append(self.transport.output_processor())
         # print(processors)
         if self._bot_config.llm:
-            processors.append(llm_assistant_ctx_aggr)
+            if self._bot_config.llm.tag and \
+                    "vision" in self._bot_config.llm.tag:
+                pass
+            else:
+                processors.append(llm_assistant_ctx_aggr)
         self.task = PipelineTask(Pipeline(processors), params=self._pipeline_params)
 
         self.transport.add_event_handler(

--- a/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
+++ b/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
@@ -428,4 +428,16 @@ class DailyRTVIGeneralBot(DailyRoomBot):
             messages[0]["content"] = self._bot_config.llm.messages[0]["content"] + \
                 " Please introduce yourself first."
             await self.task.queue_frames([LLMMessagesFrame(messages)])
+        elif self._bot_config.tts \
+                and self._bot_config.llm \
+                and self._bot_config.llm.tag \
+                and "vision" in self._bot_config.llm.tag:
+            match self._bot_config.tts.language:
+                case "zh":
+                    await self.tts_processor.say("你好，欢迎使用 Vision Bot. 我是一名虚拟助手，可以结合视频进行提问")
+                case "en":
+                    await self.tts_processor.say("Hello, welcome to use Vision Bot, I am your virtual assistant. u can ask me with video")
+                case _:
+                    await self.tts_processor.say("Hello, welcome to use Vision Bot, I am your virtual assistant. u can ask me with video")
+
         logging.info("First participant joined")

--- a/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
+++ b/src/cmd/bots/rtvi/daily_rtvi_general_bot.py
@@ -53,6 +53,14 @@ class DailyRTVIGeneralBot(DailyRoomBot):
             ),
         )
         self.init_bot_config()
+        self.init_processor()
+
+    def init_processor(self):
+        # !TODO: services to init
+        self.asr_processor = None
+        self.image_requester = None
+        self.llm_processor = None
+        self.tts_processor = None
 
     def init_bot_config(self):
         """

--- a/src/cmd/bots/run.py
+++ b/src/cmd/bots/run.py
@@ -125,6 +125,10 @@ class BotTaskRunner:
         return self._pid if self._pid else None
 
     def run_bot(self, bot_info: BotInfo):
+        if import_bots(bot_info.chat_bot_name) is False:
+            detail = f"un import bot: {bot_info.chat_bot_name}"
+            logging.error(detail)
+            return
         match bot_info.bot_type:
             case "daily":
                 self.run_daily_bot(bot_info)
@@ -168,11 +172,6 @@ class BotTaskRunnerBE(BotTaskRunner):
             if msg == "STOP":
                 logging.info(f"bot {bot_info.chat_bot_name} stopped")
                 return
-
-            if import_bots(bot_info.chat_bot_name) is False:
-                detail = f"un import bot: {bot_info.chat_bot_name}"
-                logging.error(detail)
-                continue
 
             match msg:
                 case "RUN_BOT_TASK":

--- a/src/cmd/bots/vision/daily_describe_vision_bot.py
+++ b/src/cmd/bots/vision/daily_describe_vision_bot.py
@@ -58,6 +58,7 @@ class DailyDescribeVisionBot(DailyRoomBot):
         async def on_first_participant_joined(transport: DailyTransport, participant):
             transport.capture_participant_video(participant["id"], framerate=0)
             image_requester.set_participant_id(participant["id"])
+            await tts_processor.say("你好，欢迎使用 Vision Bot. 我是一名虚拟助手，可以结合视频进行提问。")
 
         pipeline = Pipeline([
             transport.input_processor(),

--- a/src/cmd/bots/vision/daily_echo_vision_bot.py
+++ b/src/cmd/bots/vision/daily_echo_vision_bot.py
@@ -25,7 +25,7 @@ class DailyEchoVisionBot(DailyRoomBot):
 
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):
-            transport.capture_participant_video(participant["id"])
+            transport.capture_participant_video(participant["id"], framerate=0)
 
         pipeline = Pipeline([
             transport.input_processor(),

--- a/src/cmd/bots/vision/daily_mock_vision_bot.py
+++ b/src/cmd/bots/vision/daily_mock_vision_bot.py
@@ -92,6 +92,7 @@ class DailyMockVisionBot(DailyRoomBot):
         async def on_first_participant_joined(transport: DailyTransport, participant):
             transport.capture_participant_video(participant["id"], framerate=0)
             image_requester.set_participant_id(participant["id"])
+            await tts_processor.say("你好，欢迎使用 Vision Bot. 我是一名虚拟助手，可以结合视频进行提问。")
 
         pipeline = Pipeline([
             transport.input_processor(),

--- a/src/cmd/bots/vision/daily_mock_vision_bot.py
+++ b/src/cmd/bots/vision/daily_mock_vision_bot.py
@@ -1,51 +1,19 @@
-import asyncio
-from io import BytesIO
 import logging
-from typing import AsyncGenerator
 
 from PIL import Image
 from apipeline.pipeline.pipeline import Pipeline
 from apipeline.pipeline.runner import PipelineRunner
 from apipeline.pipeline.task import PipelineTask, PipelineParams
-from apipeline.frames.data_frames import Frame, TextFrame
 
+from src.processors.vision.vision_processor import MockVisionProcessor
 from src.processors.user_image_request_processor import UserImageRequestProcessor
-from src.common.utils.img_utils import image_bytes_to_base64_data_uri
-from src.processors.vision.base import VisionProcessorBase
 from src.processors.aggregators.user_response import UserResponseAggregator
 from src.processors.aggregators.vision_image_frame import VisionImageFrameAggregator
 from src.processors.speech.tts.tts_processor import TTSProcessor
 from src.common.types import DailyParams
 from src.cmd.bots.base import DailyRoomBot
 from src.transports.daily import DailyTransport
-from src.types.frames.data_frames import VisionImageRawFrame
 from .. import register_daily_room_bots
-
-
-class MockVisionLMProcessor(VisionProcessorBase):
-    """
-    use vision lm to process image frames
-    """
-
-    def __init__(
-        self,
-    ):
-        super().__init__()
-
-    async def run_vision(self, frame: VisionImageRawFrame) -> AsyncGenerator[Frame, None]:
-        logging.info(f"Mock Analyzing image: {frame}")
-
-        image = Image.frombytes(frame.mode, frame.size, frame.image)
-        with BytesIO() as buffered:
-            image.save(buffered, format=frame.format)
-            img_base64_str = image_bytes_to_base64_data_uri(
-                buffered.getvalue(), frame.format.lower())
-
-        logging.info(f"Mock img_base64_str+text: {img_base64_str} {frame.text}")
-
-        # await asyncio.sleep(1)
-
-        yield TextFrame(text=f"你好！niubility, 你他娘的是个人才。请访问 github achatbot 进行把玩, 可以在colab中部署免费把玩。")
 
 
 @register_daily_room_bots.register
@@ -63,10 +31,6 @@ class DailyMockVisionBot(DailyRoomBot):
             vad_analyzer=vad_analyzer,
             vad_audio_passthrough=True,
             transcription_enabled=False,
-            camera_out_enabled=True,
-            camera_out_is_live=True,
-            camera_out_width=1280,
-            camera_out_height=720
         )
 
         asr_processor = self.get_asr_processor()
@@ -85,7 +49,7 @@ class DailyMockVisionBot(DailyRoomBot):
         in_aggr = UserResponseAggregator()
         image_requester = UserImageRequestProcessor()
         vision_aggregator = VisionImageFrameAggregator()
-        llm_processor = MockVisionLMProcessor()
+        llm_processor = MockVisionProcessor()
         # llm_out_aggr = LLMAssistantResponseAggregator()
 
         @transport.event_handler("on_first_participant_joined")

--- a/src/processors/aggregators/vision_image_frame.py
+++ b/src/processors/aggregators/vision_image_frame.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from apipeline.frames.data_frames import Frame, ImageRawFrame, TextFrame
 from apipeline.processors.frame_processor import FrameDirection, FrameProcessor
@@ -30,7 +31,13 @@ class VisionImageFrameAggregator(FrameProcessor):
         await super().process_frame(frame, direction)
 
         if isinstance(frame, TextFrame):
-            self._describe_text = frame.text
+            # maybe use HiTextFrame
+            match = re.search(r'\[HI_TEXT\](.*?)\[/HI_TEXT\]', frame.text)
+            if match:
+                frame.text = match.group(1).strip()
+                await self.push_frame(frame, direction)
+            else:
+                self._describe_text = frame.text
         elif isinstance(frame, ImageRawFrame):
             if self._describe_text:
                 frame = VisionImageRawFrame(

--- a/src/processors/user_image_request_processor.py
+++ b/src/processors/user_image_request_processor.py
@@ -1,0 +1,27 @@
+
+from apipeline.pipeline.pipeline import FrameProcessor
+from apipeline.pipeline.task import FrameDirection
+from apipeline.frames.data_frames import Frame, TextFrame
+
+from src.types.frames.control_frames import UserImageRequestFrame
+
+
+class UserImageRequestProcessor(FrameProcessor):
+    def __init__(
+            self,
+            participant_id: str | None = None,
+            init_user_prompt: str | list = "show me the money :)",
+    ):
+        super().__init__()
+        self._participant_id = participant_id
+        self._init_user_prompt = init_user_prompt
+
+    def set_participant_id(self, participant_id: str):
+        self._participant_id = participant_id
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
+        if self._participant_id and isinstance(frame, TextFrame):
+            await self.push_frame(UserImageRequestFrame(self._participant_id), FrameDirection.UPSTREAM)
+        await self.push_frame(frame, direction)

--- a/src/processors/user_image_request_processor.py
+++ b/src/processors/user_image_request_processor.py
@@ -1,4 +1,5 @@
 
+import re
 from apipeline.pipeline.pipeline import FrameProcessor
 from apipeline.pipeline.task import FrameDirection
 from apipeline.frames.data_frames import Frame, TextFrame

--- a/src/processors/vision/vision_processor.py
+++ b/src/processors/vision/vision_processor.py
@@ -67,3 +67,29 @@ class VisionProcessor(VisionProcessorBase):
         iter = self._llm.chat_completion(self._session)
         for item in iter:
             yield TextFrame(text=item)
+
+
+class MockVisionProcessor(VisionProcessorBase):
+    """
+    just mock
+    """
+
+    def __init__(
+        self,
+    ):
+        super().__init__()
+
+    async def run_vision(self, frame: VisionImageRawFrame) -> AsyncGenerator[Frame, None]:
+        logging.info(f"Mock Analyzing image: {frame}")
+
+        image = Image.frombytes(frame.mode, frame.size, frame.image)
+        with BytesIO() as buffered:
+            image.save(buffered, format=frame.format)
+            img_base64_str = image_bytes_to_base64_data_uri(
+                buffered.getvalue(), frame.format.lower())
+
+        logging.info(f"Mock img_base64_str+text: {img_base64_str} {frame.text}")
+
+        # await asyncio.sleep(1)
+
+        yield TextFrame(text=f"你好！niubility, 你他娘的是个人才。请访问 github achatbot 进行把玩, 可以在colab中部署免费把玩。")

--- a/src/types/ai_conf.py
+++ b/src/types/ai_conf.py
@@ -27,6 +27,11 @@ DEFAULT_LLM_MODEL = os.getenv("LLM_OPENAI_MODEL", TOGETHER_LLM_MODEL)
 DEFAULT_LLM_LANG = "zh"
 
 
+class StreamConfig(BaseModel):
+    tag: Optional[str] = "daily_room_stream"
+    args: Optional[dict] = None
+
+
 class VADConfig(BaseModel):
     tag: Optional[str] = None
     args: Optional[dict] = None
@@ -58,3 +63,8 @@ class AIConfig(BaseModel):
     asr: Optional[ASRConfig] = None
     llm: Optional[LLMConfig] = None
     tts: Optional[TTSConfig] = None
+    # TODO: @weedge
+    # - use local pyaudio/cv2 streaming;
+    # - use remote RTC livekit or agora streaming
+    # need to add stream config
+    # stream: Optional[StreamConfig] = None


### PR DESCRIPTION
feat:
- add rtvi vision support: run `python -m src.cmd.http.server.fastapi_daily_bot_serve` to ready for bot run
ui:
- https://github.com/ai-bot-pro/vite-react-web-vision, run `yarn && yarn run dev`  default use rtvi mock vision to run

> [!NOTE]:
> if use task connector, default use redis queue ,  u can run the bot task worker on colab