### PR TITLE
feat: add codec modules  mimi and xcode2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "deps/FishSpeech"]
 	path = deps/FishSpeech
 	url = https://github.com/weedge/fish-speech.git
+[submodule "deps/StyleTTS2"]
+	path = deps/StyleTTS2
+	url = https://github.com/weedge/StyleTTS2.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,7 +346,7 @@ deep_translator = ["deep_translator~=1.11.4"]
 # https://huggingface.co/kyutai/mimi/blob/main/config.json transformers_version
 codec_transformers_mimi = ["transformers[torch]~=4.45.1"]
 codec_moshi_mimi = ["moshi~=0.1.0"]
-codec_xcodec2 = ["xcodec2~=0.1.3"]
+codec_xcodec2 = ["xcodec2==0.1.3"]
 
 # -----------------processor------------------
 # when use asr tts processor 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,11 @@ vision_yolo_detector = ["ultralytics~=8.3.12", "supervision~=0.24.0"]
 pytube = ["pytube~=15.0.0"]
 deep_translator = ["deep_translator~=1.11.4"]
 
+# -----------------codec------------------
+# https://huggingface.co/kyutai/mimi/blob/main/config.json transformers_version
+codec_transformers_mimi = ["transformers[torch]~=4.45.1"]
+codec_moshi_mimi = ["moshi~=0.1.0"]
+codec_xcodec2 = ["xcodec2~=0.1.3"]
 
 # -----------------processor------------------
 # when use asr tts processor 

--- a/src/modules/codec/__init__.py
+++ b/src/modules/codec/__init__.py
@@ -1,0 +1,46 @@
+import os
+import logging
+
+from dotenv import load_dotenv
+
+from src.common.factory import EngineClass, EngineFactory
+from src.types.codec import CodecArgs
+from src.modules.codec.interface import ICodec
+
+
+load_dotenv(override=True)
+
+
+class CodecEnvInit:
+    @staticmethod
+    def getEngine(tag, **kwargs) -> ICodec | EngineClass:
+        if "codec_transformers_mimi" == tag:
+            from .audio import transformers_mimi
+        elif "codec_moshi_mimi" == tag:
+            from .audio import moshi_mimi
+        elif "codec_xcodec2" == tag:
+            from .audio import xcodec2
+
+        engine = EngineFactory.get_engine_by_tag(EngineClass, tag, **kwargs)
+        return engine
+
+    @staticmethod
+    def initCodecEngine(tag=None, **kwargs) -> ICodec | EngineClass:
+        # codec
+        tag = tag or os.getenv("CODEC_TAG", "codec_xcodec2")
+        kwargs = kwargs or CodecEnvInit.map_config_func[tag]()
+        engine = CodecEnvInit.getEngine(tag, **kwargs)
+        logging.info(f"initVADEngine: {tag}, {engine}")
+        return engine
+
+    @staticmethod
+    def get_args() -> dict:
+        res = CodecArgs(model_dir=os.getenv("CODEC_MODEL_DIR", "")).__dict__
+        return res
+
+    # TAG : config
+    map_config_func = {
+        "codec_xcodec2": get_args,
+        "codec_transformers_mimi": get_args,
+        "codec_moshi_mimi": get_args,
+    }

--- a/src/modules/codec/audio/moshi_mimi.py
+++ b/src/modules/codec/audio/moshi_mimi.py
@@ -36,11 +36,13 @@ class MoshiMimiCodec(EngineClass, ICodec):
         print_model_params(self.model, "moshi-mimi")
 
     def encode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
-        vq_codes = self.model.encode(waveform_tensor)
-        logging.deug(f"encode waveform to vq_codes: {vq_codes}")
+        vq_codes = self.model.encode(
+            waveform_tensor[None, None, :].to(self.args.device)
+        )  # waveform_tensor: [1,1,T]
+        logging.debug(f"encode waveform to vq_codes: {vq_codes.shape}")
         return vq_codes
 
     def decode_code(self, vq_codes: torch.Tensor) -> torch.Tensor:
-        waveform_tensor = self.model.decode(vq_codes)
-        logging.deug(f"decode vq_codes to gen waveform: {waveform_tensor.shape}")
-        return waveform_tensor
+        waveform_tensor = self.model.decode(vq_codes.to(self.args.device))
+        logging.debug(f"decode vq_codes to gen waveform: {waveform_tensor.shape}")
+        return waveform_tensor[0][0]

--- a/src/modules/codec/audio/moshi_mimi.py
+++ b/src/modules/codec/audio/moshi_mimi.py
@@ -35,7 +35,7 @@ class MoshiMimiCodec(EngineClass, ICodec):
         self.model = loaders.get_mimi(ckpt_file, self.args.device)
         print_model_params(self.model, "moshi-mimi")
 
-    def enncode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
+    def encode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
         vq_codes = self.model.encode(waveform_tensor)
         logging.deug(f"encode waveform to vq_codes: {vq_codes}")
         return vq_codes

--- a/src/modules/codec/audio/moshi_mimi.py
+++ b/src/modules/codec/audio/moshi_mimi.py
@@ -1,0 +1,46 @@
+import logging
+import os
+
+
+try:
+    import torch
+    from moshi.models import loaders, MimiModel
+except ModuleNotFoundError as e:
+    logging.error(
+        "In order to use moshi-mimi-codec, you need to `pip install achatbot[codec_moshi_mimi]`."
+    )
+    raise Exception(f"Missing module: {e}")
+
+from src.common.factory import EngineClass
+from src.common.utils.helper import get_device, print_model_params
+from src.types.codec import CodecArgs
+from src.modules.codec.interface import ICodec
+
+
+class MoshiMimiCodec(EngineClass, ICodec):
+    """
+    PS: u can use moshi lib to get_mimi model from audio tokenizer ckpt, the same as from transformers[torch] ckpt.
+    """
+
+    TAG = "codec_moshi_mimi"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        self.args = CodecArgs(**kwargs)
+        self.args.device = self.args.device or get_device()
+        self.load_model()
+
+    def load_model(self):
+        ckpt_file = os.path.join(self.args.model_dir, loaders.MIMI_NAME)
+        self.model = loaders.get_mimi(ckpt_file, self.args.device)
+        print_model_params(self.model, "moshi-mimi")
+
+    def enncode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
+        vq_codes = self.model.encode(waveform_tensor)
+        logging.deug(f"encode waveform to vq_codes: {vq_codes}")
+        return vq_codes
+
+    def decode_code(self, vq_codes: torch.Tensor) -> torch.Tensor:
+        waveform_tensor = self.model.decode(vq_codes)
+        logging.deug(f"decode vq_codes to gen waveform: {waveform_tensor.shape}")
+        return waveform_tensor

--- a/src/modules/codec/audio/transformers_mimi.py
+++ b/src/modules/codec/audio/transformers_mimi.py
@@ -1,0 +1,55 @@
+import logging
+
+import torch
+
+try:
+    from transformers import MimiModel, AutoFeatureExtractor
+except ModuleNotFoundError as e:
+    logging.error(
+        "In order to use transoformers mimi codec, you need to `pip install achatbot[codec_transformers_mimi]`."
+    )
+    raise Exception(f"Missing module: {e}")
+
+from src.common.factory import EngineClass
+from src.common.utils.helper import print_model_params
+from src.types.codec import CodecArgs
+from src.modules.codec.interface import ICodec
+
+
+class TransformersMimiCodec(EngineClass, ICodec):
+    """
+    use transoformers[torch] mimi model and config
+    https://huggingface.co/kyutai/mimi/blob/main/config.json
+    """
+
+    TAG = "codec_transformers_mimi"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        self.args = CodecArgs(**kwargs)
+        self.load_model()
+
+    def load_model(self):
+        self.model = MimiModel.from_pretrained(self.args.model_dir)
+        self.feature_extractor = AutoFeatureExtractor.from_pretrained(self.args.model_dir)
+        self.model.eval().cuda()
+        print_model_params(self.model, "mimi")
+
+    @torch.no_grad
+    def enncode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
+        # pre-process the input waveform
+        inputs = self.feature_extractor(
+            raw_audio=waveform_tensor,
+            sampling_rate=self.feature_extractor.sampling_rate,
+            return_tensors="pt",
+        )
+
+        vq_codes = self.model.encode(inputs["input_values"])
+        logging.deug(f"encode waveform to vq_codes: {vq_codes}")
+        return vq_codes
+
+    @torch.no_grad
+    def decode_code(self, vq_codes: torch.Tensor) -> torch.Tensor:
+        waveform_tensor = self.model.decode(vq_codes)[0]
+        logging.deug(f"decode vq_codes to gen waveform: {waveform_tensor.shape}")
+        return waveform_tensor

--- a/src/modules/codec/audio/transformers_mimi.py
+++ b/src/modules/codec/audio/transformers_mimi.py
@@ -36,7 +36,7 @@ class TransformersMimiCodec(EngineClass, ICodec):
         print_model_params(self.model, "mimi")
 
     @torch.no_grad
-    def enncode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
+    def encode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
         # pre-process the input waveform
         inputs = self.feature_extractor(
             raw_audio=waveform_tensor,

--- a/src/modules/codec/audio/xcodec2.py
+++ b/src/modules/codec/audio/xcodec2.py
@@ -1,0 +1,41 @@
+import logging
+
+try:
+    import torch
+    from xcodec2.modeling_xcodec2 import XCodec2Model
+except ModuleNotFoundError as e:
+    logging.error(
+        "In order to use xcodec2-codec, you need to `pip install achatbot[codec_xcodec2]`."
+    )
+    raise Exception(f"Missing module: {e}")
+
+from src.common.factory import EngineClass
+from src.common.utils.helper import print_model_params
+from src.types.codec import CodecArgs
+from src.modules.codec.interface import ICodec
+
+
+class XCodec2Codec(EngineClass, ICodec):
+    TAG = "codec_xcodec2"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        self.args = CodecArgs(**kwargs)
+        self.load_model()
+
+    def load_model(self):
+        self.model = XCodec2Model.from_pretrained(self.args.model_dir)
+        self.model.eval().cuda()
+        print_model_params(self.model, "xcodec2")
+
+    @torch.no_grad
+    def enncode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
+        vq_codes = self.model.encode_code(input_waveform=waveform_tensor)
+        logging.deug(f"encode waveform to vq_codes: {vq_codes}")
+        return vq_codes
+
+    @torch.no_grad
+    def decode_code(self, vq_codes: torch.Tensor) -> torch.Tensor:
+        waveform_tensor = self.model.decode_code(vq_codes)
+        logging.deug(f"decode vq_codes to gen waveform: {waveform_tensor.shape}")
+        return waveform_tensor

--- a/src/modules/codec/audio/xcodec2.py
+++ b/src/modules/codec/audio/xcodec2.py
@@ -7,7 +7,9 @@ except ModuleNotFoundError as e:
     logging.error(
         "In order to use xcodec2-codec, you need to `pip install achatbot[codec_xcodec2]`."
     )
-    raise Exception(f"Missing module: {e}. Please check your PyTorch installation and dependencies.")
+    raise Exception(
+        f"Missing module: {e}. Please check your PyTorch installation and dependencies."
+    )
 
 from src.common.factory import EngineClass
 from src.common.utils.helper import print_model_params
@@ -25,7 +27,7 @@ class XCodec2Codec(EngineClass, ICodec):
 
     def load_model(self):
         self.model = XCodec2Model.from_pretrained(self.args.model_dir)
-        self.model.eval().cuda()
+        self.model.eval().to(self.args.device)
         print_model_params(self.model, "xcodec2")
 
     @torch.no_grad
@@ -39,4 +41,4 @@ class XCodec2Codec(EngineClass, ICodec):
     def decode_code(self, vq_codes: torch.Tensor) -> torch.Tensor:
         waveform_tensor = self.model.decode_code(vq_codes.to(self.args.device))
         logging.debug(f"decode vq_codes to gen waveform: {waveform_tensor.shape}")
-        return waveform_tensor
+        return waveform_tensor[0][0]

--- a/src/modules/codec/audio/xcodec2.py
+++ b/src/modules/codec/audio/xcodec2.py
@@ -29,7 +29,8 @@ class XCodec2Codec(EngineClass, ICodec):
         print_model_params(self.model, "xcodec2")
 
     @torch.no_grad
-    def enncode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
+    def encode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
+        waveform_tensor = waveform_tensor.unsqueeze(0)  # Shape: (C, T) C=1
         vq_codes = self.model.encode_code(input_waveform=waveform_tensor)
         logging.deug(f"encode waveform to vq_codes: {vq_codes}")
         return vq_codes

--- a/src/modules/codec/audio/xcodec2.py
+++ b/src/modules/codec/audio/xcodec2.py
@@ -7,7 +7,7 @@ except ModuleNotFoundError as e:
     logging.error(
         "In order to use xcodec2-codec, you need to `pip install achatbot[codec_xcodec2]`."
     )
-    raise Exception(f"Missing module: {e}")
+    raise Exception(f"Missing module: {e}. Please check your PyTorch installation and dependencies.")
 
 from src.common.factory import EngineClass
 from src.common.utils.helper import print_model_params
@@ -30,13 +30,13 @@ class XCodec2Codec(EngineClass, ICodec):
 
     @torch.no_grad
     def encode_code(self, waveform_tensor: torch.Tensor) -> torch.Tensor:
-        waveform_tensor = waveform_tensor.unsqueeze(0)  # Shape: (C, T) C=1
+        waveform_tensor = waveform_tensor.to(self.args.device).unsqueeze(0)  # Shape: (C, T) C=1
         vq_codes = self.model.encode_code(input_waveform=waveform_tensor)
-        logging.deug(f"encode waveform to vq_codes: {vq_codes}")
+        logging.debug(f"encode waveform to vq_codes: {vq_codes.shape}")
         return vq_codes
 
     @torch.no_grad
     def decode_code(self, vq_codes: torch.Tensor) -> torch.Tensor:
-        waveform_tensor = self.model.decode_code(vq_codes)
-        logging.deug(f"decode vq_codes to gen waveform: {waveform_tensor.shape}")
+        waveform_tensor = self.model.decode_code(vq_codes.to(self.args.device))
+        logging.debug(f"decode vq_codes to gen waveform: {waveform_tensor.shape}")
         return waveform_tensor

--- a/src/modules/codec/interface.py
+++ b/src/modules/codec/interface.py
@@ -14,7 +14,7 @@ class ICodec(ABC):
         Encode the given input tensor to quantized representation.
 
         Args:
-            wav_tensor (torch.Tensor): Float tensor of shape [B, C, T]
+            wav_tensor (torch.Tensor): Float tensor of shape [T]
 
         Returns:
             vq_codes (torch.Tensor): an int tensor of shape [B, K, T]
@@ -30,6 +30,6 @@ class ICodec(ABC):
             vq_codes (torch.Tensor): Int tensor of shape [B, K, T]
 
         Returns:
-            waveform_tensor (torch.Tensor): Float tensor of shape [B, C, T], the reconstructed audio.
+            waveform_tensor (torch.Tensor): Float tensor of shape [T], the reconstructed audio.
         """
         raise NotImplementedError("must be implemented in the child class")

--- a/src/modules/codec/interface.py
+++ b/src/modules/codec/interface.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+
+import torch
+
+
+class ICodec(ABC):
+    @abstractmethod
+    def load_model(self):
+        raise NotImplementedError("must be implemented in the child class")
+
+    @abstractmethod
+    def encode_code(self, wav_tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Encode the given input tensor to quantized representation.
+
+        Args:
+            wav_tensor (torch.Tensor): Float tensor of shape [B, C, T]
+
+        Returns:
+            vq_codes (torch.Tensor): an int tensor of shape [B, K, T]
+                with K the number of codebooks used and T the timestep.
+        """
+        raise NotImplementedError("must be implemented in the child class")
+
+    @abstractmethod
+    def decode_code(self, vq_codes: torch.Tensor) -> torch.Tensor:
+        """Decode the given codes to a reconstructed representation.
+
+        Args:
+            vq_codes (torch.Tensor): Int tensor of shape [B, K, T]
+
+        Returns:
+            waveform_tensor (torch.Tensor): Float tensor of shape [B, C, T], the reconstructed audio.
+        """
+        raise NotImplementedError("must be implemented in the child class")

--- a/src/types/codec/__init__.py
+++ b/src/types/codec/__init__.py
@@ -1,0 +1,9 @@
+import os
+from pydantic import BaseModel
+
+from src.common.types import MODELS_DIR
+
+
+class CodecArgs(BaseModel):
+    model_dir: str = os.path.join(MODELS_DIR, "")
+    device: str | None = None

--- a/test/modules/codec/test.py
+++ b/test/modules/codec/test.py
@@ -12,9 +12,12 @@ from src.types.codec import CodecArgs
 from src.modules.codec import CodecEnvInit, ICodec
 
 r"""
-CODEC_TAG=codec_xcodec2 python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
-CODEC_TAG=codec_moshi_mimi python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
-CODEC_TAG=codec_transformers_mimi python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
+CODEC_TAG=codec_xcodec2 CODEC_MODEL_DIR=./models/HKUSTAudio/xcodec2 \
+    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
+CODEC_TAG=codec_moshi_mimi CODEC_MODEL_DIR=./models/kyutai/moshiko-pytorch-bf16 \
+    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
+CODEC_TAG=codec_transformers_mimi CODEC_MODEL_DIR=./models/kyutai/mimi \
+    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
 """
 
 
@@ -44,12 +47,14 @@ class TestCodec(unittest.TestCase):
 
     def test_encode_decode(self):
         wav, sr = soundfile.read(self.audio_file)
-        wav_tensor = torch.from_numpy(wav).float()  # Shape: (B, C, T)
+        wav_tensor = torch.from_numpy(wav).float()  # Shape: (T)
         print(f"encode to vq codes from wav_tensor: {wav_tensor.shape}")
-        vq_code = self.codec.encode_code(self.session)
+        vq_code = self.codec.encode_code(wav_tensor)
         print(f"vq_code: {vq_code.shape}")
         wav_tensor = self.codec.decode_code(vq_code)
         print(f"decode vq_code to wav_tensor: {wav_tensor.shape}")
 
         wav_np = wav_tensor.detach().cpu().numpy()
-        soundfile.write("test_codec.wav", wav_np, sr)
+        output_path = f"{self.codec_tag}_test_codec.wav"
+        soundfile.write(output_path, wav_np, sr)
+        print(f"save to {output_path}")

--- a/test/modules/codec/test.py
+++ b/test/modules/codec/test.py
@@ -1,0 +1,44 @@
+import os
+import logging
+
+import unittest
+import soundfile
+
+from src.common.logger import Logger
+from src.common.session import Session
+from src.common.types import MODELS_DIR, SessionCtx
+from src.types.codec import CodecArgs
+from src.modules.codec import CodecEnvInit, ICodec
+
+r"""
+CODEC_TAG=codec_xcodec2 python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
+CODEC_TAG=codec_moshi_mimi python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
+CODEC_TAG=codec_transformers_mimi python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
+"""
+
+
+class TestCodec(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.codec_tag = os.getenv("CODEC_TAG", "codec_xcodec2")
+        Logger.init(os.getenv("LOG_LEVEL", "debug").upper(), is_file=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        model_dir = os.path.join(MODELS_DIR, "HKUSTAudio/xcodec2")
+        kwargs = CodecArgs(model_dir=os.getenv("CODEC_MODEL_DIR", model_dir)).__dict__
+        self.codec: ICodec = CodecEnvInit.initCodecEngine(self.codec_tag, **kwargs)
+        self.session = Session(**SessionCtx("test_codec_client_id").__dict__)
+
+    def tearDown(self):
+        pass
+
+    def test_encode_decode(self):
+        vq_code = self.codec.encode_code(self.session)
+        wav_tensor, _ = self.codec.decode_code(vq_code)
+
+        wav_np = wav_tensor.detach().cpu().numpy()
+        soundfile.write("test_codec.wav", wav_np, 24000)

--- a/test/modules/codec/test.py
+++ b/test/modules/codec/test.py
@@ -51,7 +51,7 @@ class TestCodec(unittest.TestCase):
         print(f"encode to vq codes from wav_tensor: {wav_tensor.shape}")
         vq_code = self.codec.encode_code(wav_tensor)
         print(f"vq_code: {vq_code.shape}")
-        wav_tensor = self.codec.decode_code(vq_code)
+        wav_tensor = self.codec.decode_code(vq_code)  # Shape: (T)
         print(f"decode vq_code to wav_tensor: {wav_tensor.shape}")
 
         wav_np = wav_tensor.detach().cpu().numpy()


### PR DESCRIPTION
feat:
- add codec modules: codec_xcodec2 codec_moshi_mimi codec_transformers_mimi 
- add codec test
```shell
CODEC_TAG=codec_xcodec2 CODEC_MODEL_DIR=./models/HKUSTAudio/xcodec2 \
    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
CODEC_TAG=codec_moshi_mimi CODEC_MODEL_DIR=./models/kyutai/moshiko-pytorch-bf16 \
    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
CODEC_TAG=codec_transformers_mimi CODEC_MODEL_DIR=./models/kyutai/mimi \
    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
```

colab 笔记：
- https://github.com/weedge/doraemon-nb/blob/main/achatbot_audio_codec_mimi.ipynb
- https://github.com/weedge/doraemon-nb/blob/main/achatbot_audio_codec_xcode2.ipynb

## moshi-mimi
<img width="1104" alt="image" src="https://github.com/user-attachments/assets/ddf2db28-57e5-4ccf-b508-29b4b2cf3216" />


## xcodec
![image](https://github.com/user-attachments/assets/4a4dff0e-7760-4835-8637-129a98324855)

## 

## reference
- [Moshi: a speech-text foundation model for real-time dialogue](https://arxiv.org/abs/2410.00037) (mimi) | [paper code](https://github.com/kyutai-labs/moshi)
- https://huggingface.co/kyutai/mimi
- [Codec Does Matter: Exploring the Semantic Shortcoming of Codec for Audio Language Model](https://arxiv.org/abs/2408.17175) (xcodec) | [paper code](https://github.com/zhenye234/xcodec)
- https://huggingface.co/HKUSTAudio/xcodec2
- LLaSA: Scaling Train Time and Test Time Compute for LLaMA based Speech Synthesis (xcodec2)