### PR TITLE
feat: add deepseek-ai/deepseek-vl2 deploy single Node multi GPU cards on modal

### DIFF
--- a/deploy/modal/README.md
+++ b/deploy/modal/README.md
@@ -143,6 +143,12 @@ IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=A100 LLM_MODEL_NAME_OR_PA
 IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=A100-80GB LLM_MODEL_NAME_OR_PATH=deepseek-ai/deepseek-vl2 modal serve -e achatbot src/fastapi_webrtc_vision_bot_serve.py
 # https://www.nvidia.com/en-us/data-center/h100/ 80G
 IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=H100 LLM_MODEL_NAME_OR_PATH=deepseek-ai/deepseek-vl2 modal serve -e achatbot src/fastapi_webrtc_vision_bot_serve.py
+# single Node multi GPU cards
+# deepseek-ai/deepseek-vl2-small use 2xL4
+IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=L4:2 LLM_MODEL_NAME_OR_PATH=deepseek-ai/deepseek-vl2-small modal serve -e achatbot src/fastapi_webrtc_vision_bot_serve.py
+# deepseek-ai/deepseek-vl2 use 3xL4
+IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=L4:3 LLM_MODEL_NAME_OR_PATH=deepseek-ai/deepseek-vl2 modal serve -e achatbot src/fastapi_webrtc_vision_bot_serve.py
+
 ```
 - curl api to run chat room bot with webrtc (daily/livekit/agora)
 ```shell

--- a/deploy/modal/README.md
+++ b/deploy/modal/README.md
@@ -146,8 +146,8 @@ IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=H100 LLM_MODEL_NAME_OR_PA
 # single Node multi GPU cards
 # deepseek-ai/deepseek-vl2-small use 2xL4
 IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=L4:2 LLM_MODEL_NAME_OR_PATH=deepseek-ai/deepseek-vl2-small modal serve -e achatbot src/fastapi_webrtc_vision_bot_serve.py
-# deepseek-ai/deepseek-vl2 use 3xL4
-IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=L4:3 LLM_MODEL_NAME_OR_PATH=deepseek-ai/deepseek-vl2 modal serve -e achatbot src/fastapi_webrtc_vision_bot_serve.py
+# deepseek-ai/deepseek-vl2 use 4xL4
+IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=L4:4 LLM_MODEL_NAME_OR_PATH=deepseek-ai/deepseek-vl2 modal serve -e achatbot src/fastapi_webrtc_vision_bot_serve.py
 
 ```
 - curl api to run chat room bot with webrtc (daily/livekit/agora)

--- a/deploy/modal/src/fastapi_webrtc_vision_bot_serve.py
+++ b/deploy/modal/src/fastapi_webrtc_vision_bot_serve.py
@@ -170,11 +170,11 @@ class ContainerRuntimeConfig:
                     "tts_edge,"
                     "deep_translator,together_ai,"
                     "queue"
-                    "]~=0.0.8.8.3",
+                    "]~=0.0.8.9",
                     "huggingface_hub[hf_transfer]==0.24.7",
                 ],
-                # extra_index_url="https://pypi.org/simple/",
-                extra_index_url="https://test.pypi.org/simple/",
+                extra_index_url="https://pypi.org/simple/",
+                # extra_index_url="https://test.pypi.org/simple/",
             )
             .env(
                 {

--- a/deploy/modal/src/fastapi_webrtc_vision_bot_serve.py
+++ b/deploy/modal/src/fastapi_webrtc_vision_bot_serve.py
@@ -170,11 +170,11 @@ class ContainerRuntimeConfig:
                     "tts_edge,"
                     "deep_translator,together_ai,"
                     "queue"
-                    "]~=0.0.8.8",
+                    "]~=0.0.8.8.3",
                     "huggingface_hub[hf_transfer]==0.24.7",
                 ],
-                extra_index_url="https://pypi.org/simple/",
-                # extra_index_url="https://test.pypi.org/simple/",
+                # extra_index_url="https://pypi.org/simple/",
+                extra_index_url="https://test.pypi.org/simple/",
             )
             .env(
                 {
@@ -222,7 +222,6 @@ class ContainerRuntimeConfig:
 
     @staticmethod
     def get_allow_concurrent_inputs():
-        # T4, L4, A10G, A100, H100
         concurrent_cn = int(os.getenv("IMAGE_CONCURRENT_CN", "1"))
         print(f"image_concurrent_cn:{concurrent_cn}")
         return concurrent_cn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 name = "achatbot"
 #dynamic = ["version"]
 # todo
-version = "0.0.8.8"
+version = "0.0.8.8.3"
 authors = [{ name = "weedge", email = "weege007@gmail.com" }]
 maintainers = [{ name = "weedge", email = "weege007@gmail.com" }]
 description = "An open source chat bot for voice (and multimodal) assistants"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 name = "achatbot"
 #dynamic = ["version"]
 # todo
-version = "0.0.8.8.3"
+version = "0.0.8.9"
 authors = [{ name = "weedge", email = "weege007@gmail.com" }]
 maintainers = [{ name = "weedge", email = "weege007@gmail.com" }]
 description = "An open source chat bot for voice (and multimodal) assistants"

--- a/scripts/pypi_achatbot.sh
+++ b/scripts/pypi_achatbot.sh
@@ -15,6 +15,7 @@ if [ $# -ge 1 ] && [ "$1" == "dev" ]; then
 fi
 echo "upload to $pypi"
 
+rm -rf pypi_build/app/achatbot
 mkdir -p pypi_build/app/achatbot
 
 cp -r src/* pypi_build/app/achatbot/
@@ -37,6 +38,6 @@ if [ -n "$pypi" ]; then
     else
         twine upload --verbose --skip-existing --repository $pypi dist/*
     fi
-    rm -rf pypi_build
+    rm -rf pypi_build/app/achatbot
 fi 
 

--- a/src/core/llm/transformers/manual_vision_deepseek.py
+++ b/src/core/llm/transformers/manual_vision_deepseek.py
@@ -44,7 +44,7 @@ def split_model(model_name):
         # DeepSeek-VL2-small is built on DeepSeekMoE-16B (total activated parameters are 2.8B) with 27 layers
         "deepseek-ai/deepseek-vl2-small": [13, 14],  # 2 GPU for 16b
         # DeepSeek-VL2 is built on DeepSeekMoE-27B (total activated parameters are 4.5B) with 30 layers
-        "deepseek-ai/deepseek-vl2": [8, 11, 11],  # 3 GPU for 27b
+        "deepseek-ai/deepseek-vl2": [6, 8, 8, 8],  # 3 GPU for 27b
     }
     num_layers_per_gpu = model_splits[model_name]
     num_layers = sum(num_layers_per_gpu)

--- a/src/core/llm/transformers/manual_vision_deepseek.py
+++ b/src/core/llm/transformers/manual_vision_deepseek.py
@@ -39,12 +39,12 @@ def split_model(model_name):
 
     # splits layers into different GPUs (need use L4 for bfloat16 with flash attention)
     model_splits = {
-        # DeepSeek-VL2-tiny is built on DeepSeekMoE-3B (total activated parameters are 1.0B)
+        # DeepSeek-VL2-tiny is built on DeepSeekMoE-3B (total activated parameters are 1.0B) with 12 layers
         "deepseek-ai/deepseek-vl2-tiny": [12],  # 1 GPU for 3B
-        # DeepSeek-VL2-small is built on DeepSeekMoE-16B (total activated parameters are 2.8B)
+        # DeepSeek-VL2-small is built on DeepSeekMoE-16B (total activated parameters are 2.8B) with 27 layers
         "deepseek-ai/deepseek-vl2-small": [13, 14],  # 2 GPU for 16b
-        # DeepSeek-VL2 is built on DeepSeekMoE-27B (total activated parameters are 4.5B)
-        "deepseek-ai/deepseek-vl2": [10, 10, 10],  # 3 GPU for 27b
+        # DeepSeek-VL2 is built on DeepSeekMoE-27B (total activated parameters are 4.5B) with 30 layers
+        "deepseek-ai/deepseek-vl2": [8, 11, 11],  # 3 GPU for 27b
     }
     num_layers_per_gpu = model_splits[model_name]
     num_layers = sum(num_layers_per_gpu)
@@ -78,8 +78,6 @@ class TransformersManualVisionDeepSeekVL2(TransformersBaseLLM):
 
     def __init__(self, **args) -> None:
         self.args = TransformersLMArgs(**args)
-        self.args.lm_device = self.args.lm_device or get_device()
-        logging.info("TransformersLMArgs: %s", self.args)
 
         # https://huggingface.co/deepseek-ai/deepseek-vl2/blob/main/config.json (MLA + MOE)
         # https://huggingface.co/deepseek-ai/deepseek-vl2-small/blob/main/config.json (MLA + MOE)
@@ -87,18 +85,24 @@ class TransformersManualVisionDeepSeekVL2(TransformersBaseLLM):
         config = AutoConfig.from_pretrained(self.args.lm_model_name_or_path)
         language_config = config.language_config
         language_config._attn_implementation = "eager"
-        if self.args.lm_device_map:
-            self.args.lm_device_map |= split_model(
-                "/".join(self.args.lm_model_name_or_path.split("/")[-2:])
-            )
+        if self.args.lm_device_map is not None:
+            if isinstance(self.args.lm_device_map, dict):
+                customer_deivce_map = self.args.lm_device_map
+                default_device_map = split_model(
+                    "/".join(self.args.lm_model_name_or_path.split("/")[-2:])
+                )
+                self.args.lm_device_map = {**default_device_map, **customer_deivce_map}
+            logging.info(f"TransformersLMArgs: {self.args}")
             self._model: DeepseekVLV2ForCausalLM = AutoModelForCausalLM.from_pretrained(
                 self.args.lm_model_name_or_path,
                 language_config=language_config,
                 trust_remote_code=True,
-                dtype=torch.bfloat16 if torch.cuda.is_available() else torch.float16,
+                torch_dtype=torch.bfloat16 if torch.cuda.is_available() else torch.float16,
                 device_map=self.args.lm_device_map,
             ).eval()
         else:
+            self.args.lm_device = self.args.lm_device or get_device()
+            logging.info(f"TransformersLMArgs: {self.args}")
             self._model: DeepseekVLV2ForCausalLM = AutoModelForCausalLM.from_pretrained(
                 self.args.lm_model_name_or_path,
                 language_config=language_config,
@@ -108,6 +112,7 @@ class TransformersManualVisionDeepSeekVL2(TransformersBaseLLM):
                 self.args.lm_device,
                 dtype=torch.bfloat16 if torch.cuda.is_available() else torch.float16,
             ).eval()
+        logging.info(f"TransformersLMArgs: {self.args} model.device: {self._model.device}")
         print_model_params(self._model, self.TAG)
 
         self.vl_chat_processor: DeepseekVLV2Processor = DeepseekVLV2Processor.from_pretrained(


### PR DESCRIPTION
feat:
- add deepseek-ai/deepseek-vl2 deploy single Node multi GPU cards on modal
```shell
# single Node multi GPU cards
# deepseek-ai/deepseek-vl2-small use 2xL4
IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=L4:2 LLM_MODEL_NAME_OR_PATH=deepseek-ai/deepseek-vl2-small modal serve -e achatbot src/fastapi_webrtc_vision_bot_serve.py

# deepseek-ai/deepseek-vl2 use 4xL4
IMAGE_NAME=deepseekvl2 IMAGE_CONCURRENT_CN=1 IMAGE_GPU=L4:4 LLM_MODEL_NAME_OR_PATH=deepseek-ai/deepseek-vl2 modal serve -e achatbot src/fastapi_webrtc_vision_bot_serve.py
```

```python
def split_model(model_name):
    device_map = {}

    # splits layers into different GPUs (need use L4 for bfloat16 with flash attention)
    model_splits = {
        # DeepSeek-VL2-tiny is built on DeepSeekMoE-3B (total activated parameters are 1.0B) with 12 layers
        "deepseek-ai/deepseek-vl2-tiny": [12],  # 1 GPU for 3B
        # DeepSeek-VL2-small is built on DeepSeekMoE-16B (total activated parameters are 2.8B) with 27 layers
        "deepseek-ai/deepseek-vl2-small": [13, 14],  # 2 GPU for 16b
        # DeepSeek-VL2 is built on DeepSeekMoE-27B (total activated parameters are 4.5B) with 30 layers
        "deepseek-ai/deepseek-vl2": [6, 8, 8, 8],  # 3 GPU for 27b
    }
    num_layers_per_gpu = model_splits[model_name]
    num_layers = sum(num_layers_per_gpu)
    layer_cnt = 0
    for i, num_layer in enumerate(num_layers_per_gpu):
        for j in range(num_layer):
            device_map[f"language.model.layers.{layer_cnt}"] = i
            layer_cnt += 1

    # exlude layer and last layer on cuda 0
    device_map["vision"] = 0
    device_map["projector"] = 0
    device_map["image_newline"] = 0
    device_map["view_seperator"] = 0
    device_map["language.model.embed_tokens"] = 0
    device_map["language.model.norm"] = 0
    device_map["language.lm_head"] = 0
    device_map[f"language.model.layers.{num_layers - 1}"] = 0
    return device_map
```

## deepseek-ai/deepseek-vl2-small use 2xL4

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/e7b8e64d-861c-46e7-9371-a79f76643d24" />
<img width="842" alt="image" src="https://github.com/user-attachments/assets/b9f13e1f-d39f-43b6-8cf1-10937a4fb7af" />

## deepseek-ai/deepseek-vl2 use 4xL4
device_map:
```json
                "lm_device_map": {
                    "language.model.layers.0": 0,
                    "language.model.layers.1": 0,
                    "language.model.layers.2": 0,
                    "language.model.layers.3": 0,
                    "language.model.layers.4": 0,
                    "language.model.layers.5": 0,
                    "language.model.layers.6": 1,
                    "language.model.layers.7": 1,
                    "language.model.layers.8": 1,
                    "language.model.layers.9": 1,
                    "language.model.layers.10": 1,
                    "language.model.layers.11": 1,
                    "language.model.layers.12": 1,
                    "language.model.layers.13": 1,
                    "language.model.layers.14": 2,
                    "language.model.layers.15": 2,
                    "language.model.layers.16": 2,
                    "language.model.layers.17": 2,
                    "language.model.layers.18": 2,
                    "language.model.layers.19": 2,
                    "language.model.layers.20": 2,
                    "language.model.layers.21": 2,
                    "language.model.layers.22": 3,
                    "language.model.layers.23": 3,
                    "language.model.layers.24": 3,
                    "language.model.layers.25": 3,
                    "language.model.layers.26": 3,
                    "language.model.layers.27": 3,
                    "language.model.layers.28": 3,
                    "language.model.layers.29": 0,
                    "vision": 0,
                    "projector": 0,
                    "image_newline": 0,
                    "view_seperator": 0,
                    "language.model.embed_tokens": 0,
                    "language.model.norm": 0,
                    "language.lm_head": 0
                }
```
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/33f20aea-eeba-4f40-ba10-7dbb984c1cfc" />

<img width="1469" alt="image" src="https://github.com/user-attachments/assets/3e2174ef-8414-4e3b-b326-d730d081dbb6" />


