### PR TITLE
feat: add moshi hibiki fr->en speech translate model

### DIFF
--- a/deploy/modal/README.md
+++ b/deploy/modal/README.md
@@ -108,6 +108,11 @@ curl --location 'https://weedge-achatbot--fastapi-webrtc-audio-bot-srv-app-dev.m
 modal volume put -e achatbot bot_config  ../../config/bots/fastapi_websocket_moshi_voice_bot.json / -f
 # ws_moshi_voice_bot serve on default pip image
 IMAGE_NAME=default modal serve -e achatbot src/fastapi_ws_moshi_voice_bot_serve.py
+
+# put local config to modal volume bot_config / dir
+modal volume put -e achatbot bot_config ../../config/bots/fastapi_websocket_moshi_hibiki_voice_bot.json / -f
+# ws_moshi_hibiki_voice_bot serve on default pip image
+IMAGE_NAME=default IMAGE_GPU=L4 BOT_CONFIG_NAME=fastapi_websocket_moshi_hibiki_voice_bot MODEL_NAME=kyutai/hibiki-1b-pytorch-bf16 modal serve -e achatbot src/fastapi_ws_moshi_voice_bot_serve.py
 ```
 - run moshi_opus_stream_ws_pb_client to chat with moshi in CLI
 ```shell

--- a/deploy/modal/src/fastapi_webrtc_vision_bot_serve.py
+++ b/deploy/modal/src/fastapi_webrtc_vision_bot_serve.py
@@ -215,7 +215,8 @@ class ContainerRuntimeConfig:
 
     @staticmethod
     def get_gpu():
-        # T4, L4, A10G, A100, H100
+        # https://modal.com/docs/reference/modal.gpu
+        # T4, L4, A10G, L40S, A100, A100-80GB, H100
         gpu = os.getenv("IMAGE_GPU", None)
         print(f"image_gpu:{gpu}")
         return gpu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -415,7 +415,7 @@ glm_voice_processor = [
 freeze_omni_voice_processor = [
     "achatbot[llm_transformers_manual_voice_freeze_omni]",
 ]
-moshi_voice_processor = ["moshi~=0.1.0"]
+moshi_voice_processor = ["moshi~=0.2.1"]
 
 
 #------------------------bot-------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 name = "achatbot"
 #dynamic = ["version"]
 # todo
-version = "0.0.8.9"
+version = "0.0.8.10"
 authors = [{ name = "weedge", email = "weege007@gmail.com" }]
 maintainers = [{ name = "weedge", email = "weege007@gmail.com" }]
 description = "An open source chat bot for voice (and multimodal) assistants"

--- a/src/processors/voice/moshi_voice_processor.py
+++ b/src/processors/voice/moshi_voice_processor.py
@@ -16,7 +16,7 @@ from apipeline.frames import (
 import numpy as np
 import torch
 
-from src.common.utils.helper import get_device
+from src.common.utils.helper import get_device, print_model_params
 from src.common.utils.audio_utils import (
     bytes2NpArrayWith16,
     postprocess_tts_wave_int16,
@@ -110,6 +110,7 @@ class MoshiVoiceBaseProcessor(VoiceProcessorBase):
 
         logging.info("loading mimi")
         self._mimi = self._checkpoint_info.get_mimi(device=self._device)
+        print_model_params(self._mimi, "mimi")
         logging.info("mimi loaded")
 
         logging.info("loading bpe text tokenizer")
@@ -121,12 +122,13 @@ class MoshiVoiceBaseProcessor(VoiceProcessorBase):
         condition_tensors = get_condition_tensors(
             self._checkpoint_info.model_type, self._moshi_lm, batch_size=1, cfg_coef=self._cfg_coef
         )
-        self.lm_gen = LMGen(
+        self._lm_gen = LMGen(
             self._moshi_lm,
             cfg_coef=self._cfg_coef,
             condition_tensors=condition_tensors,
             **self._lm_gen_args.__dict__,
         )
+        print_model_params(self._lm_gen, "streaming moshi lm")
         logging.info("moshi lm loaded")
 
     def load_models_v1(self):

--- a/src/processors/voice/moshi_voice_processor.py
+++ b/src/processors/voice/moshi_voice_processor.py
@@ -13,14 +13,13 @@ from apipeline.frames import (
     AudioRawFrame,
     TextFrame,
 )
-from moshi.models.loaders import DEFAULT_REPO
 import numpy as np
 import torch
 
+from src.common.utils.helper import get_device
 from src.common.utils.audio_utils import (
     bytes2NpArrayWith16,
     postprocess_tts_wave_int16,
-    resample_audio,
 )
 from src.processors.voice.base import VoiceProcessorBase
 from src.types.llm.lmgen import LMGenArgs
@@ -29,6 +28,8 @@ try:
     from sphn import OpusStreamReader, OpusStreamWriter, resample
     from sentencepiece import SentencePieceProcessor
     from moshi.models import loaders, MimiModel, LMModel, LMGen
+    from moshi.run_inference import get_condition_tensors, seed_all
+
     from huggingface_hub import hf_hub_download
 except ModuleNotFoundError as e:
     logging.error(f"Exception: {e}")
@@ -38,21 +39,13 @@ except ModuleNotFoundError as e:
     raise Exception(f"Missing module: {e}")
 
 
-def seed_all(seed):
-    torch.manual_seed(seed)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed(seed)
-        torch.cuda.manual_seed_all(seed)  # for multi-GPU setups
-    random.seed(seed)
-    np.random.seed(seed)
-    torch.backends.cudnn.deterministic = False
-    torch.backends.cudnn.benchmark = False
-
-
 class MoshiVoiceBaseProcessor(VoiceProcessorBase):
     """
-    use mimi speech codec + moshi lm(moshiko/moshika)
+    use mimi speech codec + moshi lm(moshiko/moshika, hibiki);
+    speech-text foundation model and full-duplex spoken dialogue framework
     - A1-T2A2: (speech)-to-(speech and text) (mimi(speech encoder)) -> (llm) -- text|speech tokens --> bpe(text decoder)|mimi(speech decoder))
+        - moshi (moshiko/moshika): speech-text foundation model
+        - hibiki: speech fr->en translate model
 
     NOTE:
     - moshi genative lm no system prompt and funciton call.
@@ -66,7 +59,8 @@ class MoshiVoiceBaseProcessor(VoiceProcessorBase):
         mimi_weight_file: str | None = None,
         text_tokenizer_file: str | None = None,
         moshi_weight_file: str | None = None,
-        device: str = "cuda",
+        device: str | None = None,
+        cfg_coef: float = 1.0,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -78,8 +72,10 @@ class MoshiVoiceBaseProcessor(VoiceProcessorBase):
         self._mimi_weight_file = mimi_weight_file
         self._text_tokenizer_file = text_tokenizer_file
         self._moshi_weight_file = moshi_weight_file
-        self._device = device
+        self._device = device or get_device()
+        self._cfg_coef = cfg_coef
 
+        self._checkpoint_info: loaders.CheckpointInfo = None
         self._mimi: MimiModel = None
         self._text_tokenizer: SentencePieceProcessor = None
         self._moshi_lm: LMModel = None
@@ -105,6 +101,35 @@ class MoshiVoiceBaseProcessor(VoiceProcessorBase):
         }
 
     def load_models(self):
+        self._checkpoint_info: loaders.CheckpointInfo = loaders.CheckpointInfo.from_hf_repo(
+            self._model_name,
+            self._moshi_weight_file,
+            self._mimi_weight_file,
+            self._text_tokenizer_file,
+        )
+
+        logging.info("loading mimi")
+        self._mimi = self._checkpoint_info.get_mimi(device=self._device)
+        logging.info("mimi loaded")
+
+        logging.info("loading bpe text tokenizer")
+        self._text_tokenizer = self._checkpoint_info.get_text_tokenizer()
+        logging.info("bpe text tokenizer loaded")
+
+        logging.info("loading moshi lm")
+        self._moshi_lm = self._checkpoint_info.get_moshi(device=self._device)
+        condition_tensors = get_condition_tensors(
+            self._checkpoint_info.model_type, self._moshi_lm, batch_size=1, cfg_coef=self._cfg_coef
+        )
+        self.lm_gen = LMGen(
+            self._moshi_lm,
+            cfg_coef=self._cfg_coef,
+            condition_tensors=condition_tensors,
+            **self._lm_gen_args.__dict__,
+        )
+        logging.info("moshi lm loaded")
+
+    def load_models_v1(self):
         logging.info("loading mimi")
         if self._mimi_weight_file is None:
             self._mimi_weight_file = hf_hub_download(self._model_name, loaders.MIMI_NAME)
@@ -121,7 +146,7 @@ class MoshiVoiceBaseProcessor(VoiceProcessorBase):
         self._text_tokenizer = SentencePieceProcessor(self._text_tokenizer_file)
         logging.info("loaded text tokenizer")
 
-        logging.info("loading moshi")
+        logging.info("loading moshi lm")
         if self._moshi_weight_file is None:
             self._moshi_weight_file = hf_hub_download(self._model_name, loaders.MOSHI_NAME)
         self._moshi_lm = loaders.get_moshi_lm(self._moshi_weight_file, self._device)
@@ -129,7 +154,7 @@ class MoshiVoiceBaseProcessor(VoiceProcessorBase):
             self._moshi_lm,
             **self._lm_gen_args.__dict__,
         )
-        logging.info("moshi loaded")
+        logging.info("moshi lm loaded")
 
     def warmup(self):
         logging.info("start warmup")
@@ -165,7 +190,8 @@ class MoshiVoiceOpusStreamProcessor(MoshiVoiceBaseProcessor):
         mimi_weight_file: str | None = None,
         text_tokenizer_file: str | None = None,
         moshi_weight_file: str | None = None,
-        device: str = "cuda",
+        device: str | None = None,
+        cfg_coef: float = 1.0,
         **kwargs,
     ):
         super().__init__(
@@ -175,6 +201,7 @@ class MoshiVoiceOpusStreamProcessor(MoshiVoiceBaseProcessor):
             text_tokenizer_file=text_tokenizer_file,
             moshi_weight_file=moshi_weight_file,
             device=device,
+            cfg_coef=cfg_coef,
             **kwargs,
         )
 
@@ -235,6 +262,8 @@ class MoshiVoiceOpusStreamProcessor(MoshiVoiceBaseProcessor):
 
     async def _audio_in_task_handler(self):
         self._all_pcm_data = None
+        skip_frames = 1
+
         while True:
             try:
                 pcm = self._opus_reader.read_pcm()
@@ -263,6 +292,14 @@ class MoshiVoiceOpusStreamProcessor(MoshiVoiceBaseProcessor):
 
                         # mimi encode speech tensor chunk
                         codes = self._mimi.encode(chunk)
+
+                        if skip_frames:
+                            # The first input audio frame is ignored, as from the point of
+                            # view of the model it is in the past. We still `mimi.encode` for simplicity,
+                            # however as the first encoded frame has a specific structure (due to the left padding),
+                            # we reset the streaming state of the encoder to reapply the padding on the next call.
+                            self.mimi.reset_streaming()
+                            skip_frames -= 1
 
                         for c in range(codes.shape[-1]):
                             # lm gen tokens


### PR DESCRIPTION
feat:
- add moshi hibiki fr->en **streaming speech translation** model 
- upgrade moshi==0.2.1
- deploy ws_moshi_hibiki_voice_bot on modal
```shell
# put local config to modal volume bot_config / dir
modal volume put -e achatbot bot_config ../../config/bots/fastapi_websocket_moshi_hibiki_voice_bot.json / -f

# ws_moshi_hibiki_voice_bot serve on default pip image
IMAGE_NAME=default IMAGE_GPU=L4 BOT_CONFIG_NAME=fastapi_websocket_moshi_hibiki_voice_bot MODEL_NAME=kyutai/hibiki-1b-pytorch-bf16 modal serve -e achatbot src/fastapi_ws_moshi_voice_bot_serve.py

# run moshi_opus_stream_ws_pb_client to chat with moshi in CLI
python -m achatbot.cmd.websocket.moshi_opus_stream_ws_pb_client --endpoint https://weedge-achatbot--fastapi-ws-moshi-voice-bot-srv-app-dev.modal.run/

```

## moshi
<img width="902" alt="image" src="https://github.com/user-attachments/assets/f5c18b49-cdf4-48c1-8779-198f631da6d4" />

### mimi (audio codec)
<img width="885" alt="image" src="https://github.com/user-attachments/assets/f3c0c2e4-9656-4b49-81f9-04d1820d5d2b" />

### The Helium Text Language Model params
<img width="860" alt="image" src="https://github.com/user-attachments/assets/33c72375-0ce5-42f1-a755-09267ec06153" />

### Hierarchical autoregressive modeling with RQ-Transformer
<img width="803" alt="image" src="https://github.com/user-attachments/assets/a00e364c-a040-43c0-88c8-9a91b0fdd6bb" />

### multi streaming
<img width="720" alt="image" src="https://github.com/user-attachments/assets/41631c26-6c63-4197-9d04-d680c3fc52a7" />

## hibiki
<img width="894" alt="image" src="https://github.com/user-attachments/assets/6aed9672-5267-4b08-8fa6-956fd375bcf1" />

---

- https://github.com/kyutai-labs/moshi
- https://github.com/kyutai-labs/hibiki
- [**High-Fidelity Simultaneous Speech-To-Speech Translation**](https://arxiv.org/abs/2502.03382)
- [⭐️**Moshi: a speech-text foundation model for real-time dialogue**](https://arxiv.org/abs/2410.00037)