### PR TITLE
feat: add deepseek flash mal bench on modal H100

### DIFF
--- a/deploy/modal/src/bench/run_flash_mal.py
+++ b/deploy/modal/src/bench/run_flash_mal.py
@@ -1,0 +1,44 @@
+import modal
+
+app = modal.App("ds-flash-mal")
+
+# We also define the dependencies for our Function by specifying an
+# [Image](https://modal.com/docs/guide/images).
+
+ds_flash_mal_image = (
+    # https://hub.docker.com/r/pytorch/pytorch/tags
+    modal.Image.from_registry("pytorch/pytorch:2.6.0-cuda12.6-cudnn9-devel", add_python="3.11")
+    .apt_install("git")
+    .run_commands(
+        "git clone https://github.com/deepseek-ai/FlashMLA.git",
+        "cd FlashMLA && python setup.py install",
+    )
+    .pip_install()
+)
+
+BENCH_DIR = "/data/bench"
+bench_dir = modal.Volume.from_name("bench", create_if_missing=True)
+
+
+@app.function(
+    gpu="H100",
+    retries=0,
+    image=ds_flash_mal_image,
+    volumes={BENCH_DIR: bench_dir},
+    timeout=1200,  # default 300s
+    container_idle_timeout=1200,
+)
+def flash_mal(bench_name="ds_flash_mal_bench") -> str:
+    import subprocess
+    import os
+
+    cmd = "python tests/test_flash_mla.py".split(" ")
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd="/FlashMLA")
+    print(result)
+    with open(os.path.join(BENCH_DIR, f"{bench_name}.log"),"w") as f:
+        f.write(result.stdout)
+
+
+@app.local_entrypoint()
+def main(bench_name="ds_flash_mal_bench"):
+    flash_mal.remote(bench_name)


### PR DESCRIPTION
feat: 
- add deepseek flash mal bench on modal H100
```shell
modal run src/bench/run_flash_mal.py
```

```shell
b=128, s_q=1, mean_sk=4096, h_q=16, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.215 ms, 85 TFLOPS, 2826 GB/s
b=128, s_q=1, mean_sk=4096, h_q=16, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.231 ms, 79 TFLOPS, 2649 GB/s
b=128, s_q=2, mean_sk=4096, h_q=16, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.218 ms, 168 TFLOPS, 2812 GB/s
b=128, s_q=2, mean_sk=4096, h_q=16, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.241 ms, 157 TFLOPS, 2630 GB/s
b=128, s_q=1, mean_sk=4096, h_q=32, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.218 ms, 168 TFLOPS, 2813 GB/s
b=128, s_q=1, mean_sk=4096, h_q=32, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.246 ms, 156 TFLOPS, 2617 GB/s
b=128, s_q=2, mean_sk=4096, h_q=32, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.223 ms, 327 TFLOPS, 2788 GB/s
b=128, s_q=2, mean_sk=4096, h_q=32, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.248 ms, 293 TFLOPS, 2492 GB/s
b=128, s_q=1, mean_sk=4096, h_q=64, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.223 ms, 328 TFLOPS, 2789 GB/s
b=128, s_q=1, mean_sk=4096, h_q=64, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.246 ms, 291 TFLOPS, 2477 GB/s
b=128, s_q=2, mean_sk=4096, h_q=64, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.289 ms, 506 TFLOPS, 2214 GB/s
b=128, s_q=2, mean_sk=4096, h_q=64, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.311 ms, 489 TFLOPS, 2138 GB/s
b=128, s_q=1, mean_sk=4096, h_q=128, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.286 ms, 511 TFLOPS, 2238 GB/s
b=128, s_q=1, mean_sk=4096, h_q=128, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.306 ms, 482 TFLOPS, 2110 GB/s
b=128, s_q=2, mean_sk=4096, h_q=128, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.543 ms, 538 TFLOPS, 1244 GB/s
b=128, s_q=2, mean_sk=4096, h_q=128, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.559 ms, 539 TFLOPS, 1242 GB/s
b=128, s_q=1, mean_sk=8192, h_q=16, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.405 ms, 90 TFLOPS, 2995 GB/s
b=128, s_q=1, mean_sk=8192, h_q=16, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.418 ms, 87 TFLOPS, 2900 GB/s
b=128, s_q=2, mean_sk=8192, h_q=16, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.408 ms, 179 TFLOPS, 2985 GB/s
b=128, s_q=2, mean_sk=8192, h_q=16, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.456 ms, 171 TFLOPS, 2856 GB/s
b=128, s_q=1, mean_sk=8192, h_q=32, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.408 ms, 179 TFLOPS, 2984 GB/s
b=128, s_q=1, mean_sk=8192, h_q=32, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.410 ms, 170 TFLOPS, 2831 GB/s
b=128, s_q=2, mean_sk=8192, h_q=32, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.414 ms, 353 TFLOPS, 2964 GB/s
b=128, s_q=2, mean_sk=8192, h_q=32, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.426 ms, 327 TFLOPS, 2749 GB/s
b=128, s_q=1, mean_sk=8192, h_q=64, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.413 ms, 354 TFLOPS, 2970 GB/s
b=128, s_q=1, mean_sk=8192, h_q=64, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.429 ms, 326 TFLOPS, 2738 GB/s
b=128, s_q=2, mean_sk=8192, h_q=64, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.565 ms, 517 TFLOPS, 2201 GB/s
b=128, s_q=2, mean_sk=8192, h_q=64, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.573 ms, 525 TFLOPS, 2235 GB/s
b=128, s_q=1, mean_sk=8192, h_q=128, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.562 ms, 520 TFLOPS, 2214 GB/s
b=128, s_q=1, mean_sk=8192, h_q=128, h_kv=1, d=576, dv=512, causal=True, varlen=True
0.609 ms, 513 TFLOPS, 2179 GB/s
b=128, s_q=2, mean_sk=8192, h_q=128, h_kv=1, d=576, dv=512, causal=True, varlen=False
1.049 ms, 557 TFLOPS, 1220 GB/s
b=128, s_q=2, mean_sk=8192, h_q=128, h_kv=1, d=576, dv=512, causal=True, varlen=True
1.027 ms, 558 TFLOPS, 1223 GB/s
```
在H100上测试； memory-bound 可以 最高到 2995 GB/s；computation-bound  可以到 558 TFLOPS
```
b=128, s_q=1, mean_sk=8192, h_q=16, h_kv=1, d=576, dv=512, causal=True, varlen=False
0.405 ms, 90 TFLOPS, 2995 GB/s
b=128, s_q=2, mean_sk=8192, h_q=128, h_kv=1, d=576, dv=512, causal=True, varlen=True
1.027 ms, 558 TFLOPS, 1223 GB/s
```

官方在H800上的结果（主要还是正对H800做的优化）：
```
Achieving up to 3000 GB/s in memory-bound configuration and 580 TFLOPS in computation-bound configuration on H800 SXM5, using CUDA 12.6.
```