### PR TITLE
feat: add audio size field for podcast; compress gen img; gen podcasts xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,6 @@ runs
 
 #ruff
 .ruff_cache/
+
+# xml
+*.xml

--- a/demo/audio_length.py
+++ b/demo/audio_length.py
@@ -1,0 +1,83 @@
+import logging
+import os
+import requests
+from io import BytesIO
+import mutagen
+from mutagen.mp3 import MP3
+from mutagen.oggvorbis import OggVorbis
+from mutagen.flac import FLAC
+from mutagen.wave import WAVE
+from mutagen.aiff import AIFF
+
+import typer
+
+app = typer.Typer()
+
+
+def get_audio_file_length(audio_file_path: str) -> float | None:
+    """
+    Retrieves the length of an audio file path
+
+    Args:
+        audio_file: the audio file path.
+
+    Returns:
+        The length of the audio file in seconds, or None if the length could not be determined.
+    """
+    if not os.path.exists(audio_file_path):
+        print(f"Error: File not found: {audio_file_path}")
+        return None
+    file_size = os.path.getsize(audio_file_path)
+    logging.info(f"os.path.getsize: {file_size}")
+    return file_size
+
+
+def get_audio_url_length(audio_url: str) -> float | None:
+    """
+    Retrieves the length of an audio file from a URL.
+
+    Args:
+        audio_url: The URL of the audio file.
+
+    Returns:
+        The length of the audio file in seconds, or None if the length could not be determined.
+    """
+    try:
+        # headers = {"Range": "bytes=0-102400"}  # Get the first 100KB, should be enough for metadata.
+        response = requests.get(audio_url, stream=False, timeout=60)
+        response.raise_for_status()  # Raise an exception for bad status codes
+
+        content_length = response.headers.get("Content-Length")
+        if content_length:
+            file_size = int(content_length)
+            logging.info(f"File size: {file_size} bytes")
+            return file_size
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error: Could not retrieve audio file from URL: {e}")
+        return None
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        return None
+
+
+@app.command("get_audio_length")
+def get_audio_length(audio: str) -> float | None:
+    if audio.startswith("http"):
+        res = get_audio_url_length(audio)
+    else:
+        res = get_audio_file_length(audio)
+
+    return res
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(pathname)s:%(lineno)d - %(funcName)s - %(message)s",
+        handlers=[
+            # logging.FileHandler("content_parser_tts.log"),
+            logging.StreamHandler()
+        ],
+    )
+    app()

--- a/demo/cloudflare/rest_api.py
+++ b/demo/cloudflare/rest_api.py
@@ -42,7 +42,7 @@ def d1_table_query(db_id: str, sql: str, sql_params: List[str] = []) -> dict:
     data = res.read().decode("utf-8")
     # print(data)
     json_data = json.loads(data)
-    logging.info(f"body:{body}, db_id:{db_id}, query res:{json_data}")
+    # logging.info(f"body:{body}, db_id:{db_id}, query res:{json_data}")
     return json_data
 
 

--- a/demo/gen_podcasts_xml.py
+++ b/demo/gen_podcasts_xml.py
@@ -1,0 +1,169 @@
+import logging
+import os
+from datetime import datetime
+import html
+from typing import List, Dict
+
+import typer
+from dotenv import load_dotenv
+import xml.etree.ElementTree as ET
+
+from demo.cloudflare.rest_api import d1_table_query
+from demo.aws.upload import r2_upload
+
+# Load environment variables from .env file
+load_dotenv(override=True)
+app = typer.Typer()
+
+
+def escape_xml(text: str) -> str:
+    """Escapes XML special characters in a string."""
+    return html.escape(text, quote=True)
+
+
+def format_date_to_rfc822(date_string: str) -> str:
+    """
+    Formats a date string (YYYY-MM-DD HH:MM:SS) to RFC 822 format.
+    """
+    try:
+        # Assuming the input date string includes time as well
+        date_obj = datetime.strptime(date_string, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        try:
+            # Try parsing without time
+            date_obj = datetime.strptime(date_string, "%Y-%m-%d")
+        except ValueError:
+            # If both formats fail, raise an error
+            raise ValueError("Incorrect date format, should be YYYY-MM-DD or YYYY-MM-DD HH:MM:SS")
+
+    return date_obj.strftime("%a, %d %b %Y %H:%M:%S +0000")
+
+
+def generate_podcast_feed_xml(podcasts: List[Dict]) -> str:
+    """Generates an RSS feed XML string for a list of podcasts.
+
+    https://help.apple.com/itc/podcasts_connect/#/itcbaf351599
+
+    Args:
+        podcasts: A list of dictionaries, where each dictionary represents a podcast
+                  and contains the following keys:
+                  - 'title': str, required
+                  - 'description': str, required
+                  - 'pid': str, required, unique identifier
+                  - 'create_time': str, required, in YYYY-MM-DD HH:MM:SS format
+                  - 'audio_url': str, required
+                  - 'audio_size': int, required
+                  - 'duration': int, required, in second format
+                  - 'cover_img_url': str, required, the url of image
+                  - 'source': str, optional.
+    Returns:
+        A string containing the generated RSS feed XML.
+    """
+
+    channel_title = "AI Podcast"  # Replace with your podcast name
+    channel_description = "Latest podcasts about AI Technology and Papers."  # Replace with your podcast description  # Replace with your podcast description
+    channel_link = "https://weedge.us.kg"  # Replace with your website URL
+    channel_language = "en-us"
+    channel_image_url = (
+        "https://weedge.us.kg/an_AI_podcast_1400.jpg"  # Replace with your podcast image
+    )
+
+    # <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    rss = ET.Element(
+        "rss",
+        version="2.0",
+        attrib={
+            "xmlns:itunes": "http://www.itunes.com/dtds/podcast-1.0.dtd",
+            "xmlns:atom": "http://www.w3.org/2005/Atom",
+            "xmlns:podcast": "https://podcastindex.org/namespace/1.0",
+            "xmlns:content": "http://purl.org/rss/1.0/modules/content/",
+        },
+    )
+    channel = ET.SubElement(rss, "channel")
+    ET.SubElement(channel, "title").text = channel_title
+    ET.SubElement(channel, "itunes:author").text = "weedge"
+    ET.SubElement(channel, "itunes:explicit").text = "false"
+    ET.SubElement(channel, "itunes:image", href=channel_image_url)
+    ET.SubElement(channel, "itunes:category", text="Technology")
+    ET.SubElement(channel, "link").text = channel_link
+    ET.SubElement(channel, "description").text = channel_description
+    ET.SubElement(channel, "language").text = channel_language
+    ET.SubElement(channel, "copyright").text = "&#169; 2024-2025 weedge"
+    ET.SubElement(
+        channel,
+        "atom:link",
+        href="https://pub-f8da0a7ab3e74cc8a8081b2d4b8be851.r2.dev/rss.xml",
+        rel="self",
+        type="application/rss+xml",
+    )
+
+    image = ET.SubElement(channel, "image")
+    ET.SubElement(image, "url").text = channel_image_url
+    ET.SubElement(image, "title").text = channel_title
+    ET.SubElement(image, "link").text = channel_link
+
+    for podcast in podcasts:
+        item = ET.SubElement(channel, "item")
+
+        item_title = escape_xml(podcast["title"])
+        item_author = escape_xml(podcast["author"])
+        item_description = escape_xml(podcast["description"])
+
+        item_link = f"https://weedge.us.kg/podcast/{podcast['pid']}"
+
+        item_pub_date = format_date_to_rfc822(podcast["create_time"])
+        item_audio_url = escape_xml(podcast["audio_url"])
+        item_audio_length = str(podcast["audio_size"])
+
+        duration_seconds = podcast["duration"]
+        minutes, seconds = divmod(duration_seconds, 60)
+        hours, minutes = divmod(minutes, 60)
+        item_duration = (
+            "{:02d}:{:02d}:{:02d}".format(int(hours), int(minutes), int(seconds))
+            if hours
+            else "{:02d}:{:02d}".format(int(minutes), int(seconds))
+        )
+
+        ET.SubElement(item, "title").text = item_title
+        ET.SubElement(item, "author").text = item_author
+        ET.SubElement(item, "description").text = item_description
+        ET.SubElement(item, "link").text = item_link
+        ET.SubElement(item, "guid").text = item_link
+        ET.SubElement(item, "pubDate").text = item_pub_date
+
+        ET.SubElement(
+            item, "enclosure", url=item_audio_url, length=item_audio_length, type="audio/mpeg"
+        )
+
+        ET.SubElement(item, "itunes:duration").text = item_duration
+        ET.SubElement(item, "itunes:explicit").text = "false"
+
+    xml_string = ET.tostring(rss, encoding="UTF-8", xml_declaration=True).decode("utf-8")
+    return xml_string
+
+
+@app.command("gen_xml_from_d1_podcast")
+def gen_xml_from_d1_podcast(is_upload: bool = False):
+    db_id = os.getenv("PODCAST_D1_DB_ID")
+    select_sql = "select * from podcast where audio_size>0 and is_published is True order by create_time desc;"
+    select_res = d1_table_query(db_id, select_sql)
+    podcasts_data = select_res["result"][0]["results"]
+
+    rss_xml = generate_podcast_feed_xml(podcasts_data)
+    # print(rss_xml)
+
+    # Optionally, save to a file:
+    with open("rss.xml", "w", encoding="utf-8") as f:
+        f.write(rss_xml)
+
+    if is_upload:
+        r2_upload("podcast", "rss.xml")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(pathname)s:%(lineno)d - %(funcName)s - %(message)s",
+        handlers=[logging.StreamHandler()],
+    )
+    app()

--- a/demo/image_compression.py
+++ b/demo/image_compression.py
@@ -1,0 +1,108 @@
+import logging
+import os
+import io
+from PIL import Image
+
+import typer
+
+from demo.aws.upload import r2_upload
+
+app = typer.Typer()
+
+
+@app.command("compress_img")
+def compress_img(
+    img_path: str,
+    file_name: str = "",
+    save_dir: str = "./images",
+    quality: int = 60,
+):
+    """Compresses a single image.
+
+    Args:
+        img_path: Path to the input image.
+        file_name: Desired file name for the compressed image.
+        save_dir: Directory to save the compressed image.
+        quality: Compression quality (0-100).
+    """
+    if not os.path.isfile(img_path):
+        raise Exception(f"image not found: {img_path}")
+
+    f = os.path.basename(img_path).split(".")
+    ext = f".{f[-1]}"
+    if not file_name:
+        file_name = f[0] + f"_{quality}"
+    save_name = os.path.join(save_dir, file_name)
+    img = Image.open(img_path)
+    if img.format == "PNG":
+        img = img.convert("RGB")
+        ext = ".jpg"
+    else:
+        img = img.quantize(colors=256)
+    save_path = save_name + ext
+    img.save(save_path, optimize=True, quality=quality, subsampling=-1)
+    return save_path
+
+
+@app.command("compress_imgs")
+def compress_imgs(
+    img_dir: str = "./images",
+    save_dir: str = "images",
+    quality: int = 60,
+):
+    """Compresses and uploads all JPG images in a directory to R2.
+
+    Args:
+        img_dir: Directory containing the images to compress and upload.
+        remote_folder: Remote folder in R2 to upload to.
+        quality: Compression quality (0-100).
+    """
+    if not os.path.isdir(img_dir) and not os.path.exists(save_dir):
+        raise Exception(f"image directory not found: {img_dir} or {save_dir}")
+    for file_name in os.listdir(img_dir):
+        if file_name.endswith(".png"):
+            img_path = os.path.join(img_dir, file_name)
+            save_path = compress_img(
+                img_path=img_path,
+                save_dir=img_dir,
+                quality=quality,
+            )
+            logging.info(f"compress {img_path} to {save_path}")
+        else:
+            logging.info(f"skip {file_name}")
+
+
+@app.command("upload_imgs")
+def upload_imgs(img_dir: str = "./images", remote_folder: str = "podcast"):
+    """Upload all JPG images in a directory to R2.
+
+    Args:
+        img_dir: Directory containing the images to compress and upload.
+        remote_folder: Remote folder in R2 to upload to.
+    """
+    if not os.path.isdir(img_dir):
+        raise Exception(f"image directory not found: {img_dir}")
+    for file_name in os.listdir(img_dir):
+        if file_name.endswith(".jpg"):
+            img_path = os.path.join(img_dir, file_name)
+            # Upload the image
+            r2_url = r2_upload(remote_folder=remote_folder, local_file=img_path)
+            logging.info(f"Uploaded {img_path} to R2: {r2_url}")
+        else:
+            logging.info(f"skip {file_name}")
+
+
+r"""
+python -m demo.image_compression compress_img images/0_123.png
+python -m demo.image_compression compress_img images/0_123.png --quality 60
+
+python -m demo.image_compression compress_and_upload_imgs
+python -m demo.image_compression upload_imgs
+"""
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(pathname)s:%(lineno)d - %(funcName)s - %(message)s",
+        handlers=[logging.StreamHandler()],
+    )
+    app()

--- a/demo/together_ai.py
+++ b/demo/together_ai.py
@@ -43,7 +43,7 @@ def gen_image(
     return res
 
 
-@app.command("save_image")
+@app.command("save_gen_image")
 def save_gen_image(
     prompt: str,
     file_name: str,
@@ -67,7 +67,7 @@ def save_gen_image(
 
 r"""
 python -m demo.image_together_flux gen_image "llama, sitting in a field of flowers"
-python -m demo.image_together_flux save_image "llama, sitting in a field of flowers" 123 --n 2
+python -m demo.image_together_flux save_gen_image "llama, sitting in a field of flowers" 123 --n 2
 """
 if __name__ == "__main__":
     logging.basicConfig(


### PR DESCRIPTION
feat: 
- add audio size field for podcast; 
- compress gen img; 
- gen podcasts xml；

---

- AI Podcast 地址 https://weedge.us.kg/ (试了下国内可以访问，不过需要多试几次) | cloudflare 提供的地址：https://podcast-997.pages.dev/  cloudflare ❤
- frontend code：https://github.com/ai-bot-pro/react-nextjs-web-podcast (可作为数据的展现和落地页，前后端一起，没有使用静态页面的部署方式)
- Apple Podcast https://podcasts.apple.com/us/podcast/ai-podcast/id1798858172 (使用apple podcast 订阅 RSS xml, 其他平台类似)

PS: RSS xml web1.0 时代的产物(xml在java中一直沿用)； 现在的AI 编程可以干web1.0时代大部分的活了

---
总结：
前端 和 后端的脚本 AIGC 内容 的代码pipeline实现 使用了 gemini code assist + github copilot + cline + 通义千问  这些AI辅助工具, 实践体验：
- 按照项目上下文来生成，fix 
- 按照当前文件函数，文件上下文来 tab 生成
- 空文件，直接提出文件是做什么用的，初始代码一句话一键生成，甚至都不要修改
- 理解已有代码，画出流程图， 而且支持 markdown 格式
- 以及函数解释，文档生成。
- review，提交的github分支上进行CR，效率高，常规错误多会标注不同等级。
- 加上快捷键，AI时代的VIM。

关键是提出问题了，解决问题由AI大部分辅助，加点人工审核review,  效率提高不少


PS: 后续把 podcast 相关代码迁移出来，可能会放到 offline pipeline [apipeai](https://github.com/weedge/apipeai)
