### PR TITLE
feat: add SNAC codec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,6 +306,7 @@ codec_bitokenizer = [
     "torchvision==0.20.1",
     "transformers==4.46.2",
 ]
+codec_snac = ["snac"]
 
 # ---------------TTS----------------------
 

--- a/src/modules/codec/__init__.py
+++ b/src/modules/codec/__init__.py
@@ -24,6 +24,8 @@ class CodecEnvInit:
             from .audio import xcodec2
         elif "codec_bitokenizer" == tag:
             from .audio import bicodec
+        elif "codec_snac" == tag:
+            from .audio import snac
 
         engine = EngineFactory.get_engine_by_tag(EngineClass, tag, **kwargs)
         return engine
@@ -44,6 +46,7 @@ class CodecEnvInit:
 
     # TAG : config
     map_config_func = {
+        "codec_snac": get_args,
         "codec_bitokenizer": get_args,
         "codec_xcodec2": get_args,
         "codec_transformers_mimi": get_args,

--- a/src/modules/codec/audio/snac.py
+++ b/src/modules/codec/audio/snac.py
@@ -1,0 +1,57 @@
+import logging
+import os
+from typing import List
+
+
+try:
+    import torch
+    from snac import SNAC
+except ModuleNotFoundError as e:
+    logging.error("In order to use SNAC-codec, you need to `pip install achatbot[codec_snac]`.")
+    raise Exception(f"Missing module: {e}")
+
+from src.common.factory import EngineClass
+from src.common.utils.helper import get_device, print_model_params
+from src.types.codec import CodecArgs
+from src.modules.codec.interface import ICodec
+
+
+class SNACCodec(EngineClass, ICodec):
+    """
+    Multi-Scale Neural Audio Codec (SNAC) compresses audio into discrete codes at a low bitrate
+    - https://arxiv.org/abs/2410.14411
+    - https://github.com/hubertsiuzdak/snac
+    - https://huggingface.co/hubertsiuzdak/snac_24khz (for 🗣️ Speech)
+    - https://huggingface.co/hubertsiuzdak/snac_32khz (for 🎸 Music / Sound Effects)
+    - https://huggingface.co/hubertsiuzdak/snac_44khz (for 🎸 Music / Sound Effects)
+    """
+
+    TAG = "codec_snac"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        self.args = CodecArgs(**kwargs)
+        self.args.device = self.args.device or get_device()
+        logging.info("CodecArgs: %s", self.args)
+        self.load_model()
+
+    def load_model(self):
+        self.model = SNAC.from_pretrained(self.args.model_dir).to(self.args.device).eval()
+        print_model_params(self.model, "snac")
+
+    @torch.inference_mode()
+    def encode_code(self, waveform_tensor: torch.Tensor) -> List[torch.Tensor]:
+        vq_codes_list = self.model.encode(
+            waveform_tensor[None, None, :].to(self.args.device)
+        )  # waveform_tensor: [1,1,T]
+        logging.debug(f"encode waveform to vq_codes cn: {len(vq_codes_list)}")
+        return vq_codes_list
+
+    @torch.inference_mode()
+    def decode_code(self, vq_codes: List[torch.Tensor]) -> torch.Tensor:
+        if not isinstance(vq_codes, list):
+            vq_codes = vq_codes.to(self.args.device)
+            vq_codes = [vq_codes.squeeze(0)]  # [[1,T]]
+        waveform_tensor = self.model.decode(vq_codes)
+        logging.debug(f"decode vq_codes to gen waveform: {waveform_tensor.shape}")
+        return waveform_tensor[0][0]

--- a/src/modules/codec/audio/snac.py
+++ b/src/modules/codec/audio/snac.py
@@ -6,9 +6,9 @@ from typing import List
 try:
     import torch
     from snac import SNAC
-except ModuleNotFoundError as e:
+except ImportError as e:
     logging.error("In order to use SNAC-codec, you need to `pip install achatbot[codec_snac]`.")
-    raise Exception(f"Missing module: {e}")
+    raise ImportError(f"Missing module: {e}")
 
 from src.common.factory import EngineClass
 from src.common.utils.helper import get_device, print_model_params

--- a/test/modules/codec/test.py
+++ b/test/modules/codec/test.py
@@ -24,6 +24,12 @@ CODEC_TAG=codec_transformers_dac CODEC_MODEL_DIR=./models/descript/dac_44khz \
     python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
 CODEC_TAG=codec_bitokenizer CODEC_MODEL_DIR=./models/SparkAudio/Spark-TTS-0.5B \
     python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
+CODEC_TAG=codec_snac CODEC_MODEL_DIR=./models/hubertsiuzdak/snac_24khz \
+    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
+CODEC_TAG=codec_snac CODEC_MODEL_DIR=./models/hubertsiuzdak/snac_32khz \
+    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
+CODEC_TAG=codec_snac CODEC_MODEL_DIR=./models/hubertsiuzdak/snac_44khz \
+    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
 """
 
 


### PR DESCRIPTION
feat:
- add SNAC codec and unit test

```shell
# download ckpt
huggingface-cli download hubertsiuzdak/snac_24khz --quie --local-dir ./models/hubertsiuzdak/snac_24khz
huggingface-cli download hubertsiuzdak/snac_32khz --quie --local-dir ./models/hubertsiuzdak/snac_32khz
huggingface-cli download hubertsiuzdak/snac_44khz --quie --local-dir ./models/hubertsiuzdak/snac_44khz

# test
CODEC_TAG=codec_snac CODEC_MODEL_DIR=./models/hubertsiuzdak/snac_24khz \
    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
CODEC_TAG=codec_snac CODEC_MODEL_DIR=./models/hubertsiuzdak/snac_32khz \
    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
CODEC_TAG=codec_snac CODEC_MODEL_DIR=./models/hubertsiuzdak/snac_44khz \
    python -m unittest test.modules.codec.test.TestCodec.test_encode_decode
```

---

- [SNAC: Multi-Scale Neural Audio Codec](https://arxiv.org/abs/2410.14411v1) |  [paper code](https://github.com/hubertsiuzdak/snac)

<img width="818" alt="image" src="https://github.com/user-attachments/assets/68da3afb-e8d4-4db3-8f64-b80f5fb4e1cc" />


Multi-Scale Neural Audio Codec (SNAC) compresses audio into discrete codes at a low bitrate
    - https://arxiv.org/abs/2410.14411
    - https://github.com/hubertsiuzdak/snac
    - https://huggingface.co/hubertsiuzdak/snac_24khz (for 🗣️ Speech)
    - https://huggingface.co/hubertsiuzdak/snac_32khz (for 🎸 Music / Sound Effects)
    - https://huggingface.co/hubertsiuzdak/snac_44khz (for 🎸 Music / Sound Effects)


总结：

- 通过应用可变帧速率的量化器层次结构，编解码器可以适应多个时间尺度上的音频结构；
- 虽然实现更高效的压缩, 但是重新生成的中文音频质量相对比较差；
- 在 RVQGAN [2023.6 High-Fidelity Audio Compression with Improved RVQGAN](https://arxiv.org/abs/2306.06546) |[paper code](https://github.com/descriptinc/descript-audio-codec) encoder-decoder 结构 基础上进行扩展， 训练过程借鉴了 DAC: [⭐️ 2023.6 High-Fidelity Audio Compression with Improved RVQGAN](https://arxiv.org/abs/2306.06546) | [paper code](https://github.com/descriptinc/descript-audio-codec)
- 可以使用DAC训练源码进行复现，SNAC的训练参数量很少，单卡就行。


最近发布的Orpheus-TTS 使用snac_24khz 作为decoder 生成语音
- https://github.com/canopyai/Orpheus-TTS
- https://github.com/canopyai/Orpheus-Speech-PyPi/blob/main/orpheus_tts/decoder.py
- https://canopylabs.ai/model-releases (观望后续发布的端到端的语音交互模型)
- https://huggingface.co/collections/canopylabs/orpheus-tts-67d9ea3f6c05a941c06ad9d2
