### PR TITLE
feat: add transformers, llamacpp, vllm, sglang, tensorrt-llm engine generator

### DIFF
--- a/deploy/modal/src/download_models.py
+++ b/deploy/modal/src/download_models.py
@@ -62,6 +62,8 @@ modal run src/download_models.py --repo-ids "SparkAudio/Spark-TTS-0.5B"
 
 modal run src/download_models.py --repo-ids "canopylabs/orpheus-3b-0.1-ft"
 modal run src/download_models.py --repo-ids "hubertsiuzdak/snac_24khz"
+
+modal run src/download_models.py --repo-ids "Qwen/Qwen2.5-0.5B"
 """
 
 

--- a/deploy/modal/src/llm/sglang/examples/generate.py
+++ b/deploy/modal/src/llm/sglang/examples/generate.py
@@ -1,0 +1,124 @@
+import os
+import modal
+
+app = modal.App("sglang-generate")
+
+sglang_image = modal.Image.debian_slim(
+    python_version="3.11"
+).pip_install(  # add sglang and some Python dependencies
+    # as per sglang website: https://sgl-project.github.io/start/install.html
+    "flashinfer-python",
+    "sglang[all]>=0.4.4.post1",
+    extra_options="--find-links https://flashinfer.ai/whl/cu124/torch2.5/flashinfer/",
+    extra_index_url="https://flashinfer.ai/whl/cu124/torch2.5/",
+)
+
+HF_MODEL_DIR = "/root/models"
+hf_model_vol = modal.Volume.from_name("models", create_if_missing=True)
+
+
+@app.function(
+    gpu=os.getenv("IMAGE_GPU", "T4"),
+    cpu=2.0,
+    retries=0,
+    image=sglang_image,
+    volumes={
+        HF_MODEL_DIR: hf_model_vol,
+    },
+    timeout=1200,  # default 300s
+    scaledown_window=1200,
+    max_containers=100,
+)
+def run_sync():
+    from sglang import Engine
+
+    engine = Engine(
+        model_path="/root/models/Qwen/Qwen2.5-0.5B",
+    )
+
+    iterator = engine.generate(
+        prompt="Hello, my name is",
+        sampling_params={
+            "n": 1,  # number of samples to generate
+            "max_new_tokens": 2,
+            "temperature": 0.95,
+            "top_p": 0.8,
+            "top_k": 20,
+            "min_p": 0.0,
+            # Penalizers
+            "repetition_penalty": 1.1,
+            "min_new_tokens": 0,
+        },
+        stream=True,
+        return_logprob=True,
+    )
+    i = 1
+    for part in iterator:
+        print(part)
+        meta_info = part["meta_info"]
+        if "output_token_logprobs" in meta_info and len(meta_info["output_token_logprobs"]) > 0:
+            token_id = meta_info["output_token_logprobs"][-1][1]
+            print(token_id)
+        if i == 3:
+            print("stopping")
+            break
+        i += 1
+
+
+@app.function(
+    gpu=os.getenv("IMAGE_GPU", "T4"),
+    cpu=2.0,
+    retries=0,
+    image=sglang_image,
+    volumes={
+        HF_MODEL_DIR: hf_model_vol,
+    },
+    timeout=1200,  # default 300s
+    scaledown_window=1200,
+    max_containers=100,
+)
+async def run_async():
+    import uuid
+    from sglang import Engine
+    from sglang.srt.managers.io_struct import GenerateReqInput
+
+    engine = Engine(
+        model_path="/root/models/Qwen/Qwen2.5-0.5B",
+    )
+
+    obj = GenerateReqInput(
+        text="Hello, my name is",
+        rid=str(uuid.uuid4().hex),
+        sampling_params={
+            "n": 1,  # number of samples to generate
+            "max_new_tokens": 2,
+            "temperature": 0.95,
+            "top_p": 0.8,
+            "top_k": 20,
+            "min_p": 0.0,
+            # Penalizers
+            "repetition_penalty": 1.1,
+            "min_new_tokens": 0,
+        },
+        stream=True,
+        return_logprob=True,
+    )
+    generator = engine.tokenizer_manager.generate_request(obj, None)
+
+    i = 1
+    async for part in generator:
+        print(part)
+        meta_info = part["meta_info"]
+        if "output_token_logprobs" in meta_info and len(meta_info["output_token_logprobs"]) > 0:
+            token_id = meta_info["output_token_logprobs"][-1][1]
+            print(token_id)
+        if i == 3:
+            print("stopping")
+            break
+        i += 1
+
+
+"""
+modal run src/llm/sglang/examples/generate.py::run_sync (stream)
+modal run src/llm/sglang/examples/generate.py::run_async (stream)
+"""

--- a/deploy/modal/src/llm/sglang/examples/generate.py
+++ b/deploy/modal/src/llm/sglang/examples/generate.py
@@ -36,7 +36,7 @@ def run_sync():
         model_path="/root/models/Qwen/Qwen2.5-0.5B",
     )
 
-    iterator = engine.generate(
+    iterator = engine.generate(  # no request_id param :(
         prompt="Hello, my name is",
         sampling_params={
             "n": 1,  # number of samples to generate

--- a/deploy/modal/src/llm/sglang/examples/generate.py
+++ b/deploy/modal/src/llm/sglang/examples/generate.py
@@ -3,14 +3,20 @@ import modal
 
 app = modal.App("sglang-generate")
 
-sglang_image = modal.Image.debian_slim(
-    python_version="3.11"
-).pip_install(  # add sglang and some Python dependencies
-    # as per sglang website: https://sgl-project.github.io/start/install.html
-    "flashinfer-python",
-    "sglang[all]>=0.4.4.post1",
-    extra_options="--find-links https://flashinfer.ai/whl/cu124/torch2.5/flashinfer/",
-    extra_index_url="https://flashinfer.ai/whl/cu124/torch2.5/",
+sglang_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install(  # add sglang and some Python dependencies
+        # as per sglang website: https://sgl-project.github.io/start/install.html
+        "flashinfer-python",
+        "sglang[all]>=0.4.4.post1",
+        extra_options="--find-links https://flashinfer.ai/whl/cu124/torch2.5/flashinfer/",
+        extra_index_url="https://flashinfer.ai/whl/cu124/torch2.5/",
+    )
+    .env(
+        {
+            "TORCH_CUDA_ARCH_LIST": "7.5,8.0 8.6 8.7 8.9 9.0",
+        }
+    )
 )
 
 HF_MODEL_DIR = "/root/models"

--- a/deploy/modal/src/llm/sglang/examples/generate.py
+++ b/deploy/modal/src/llm/sglang/examples/generate.py
@@ -148,7 +148,6 @@ async def run_achatbot_generator():
         SGlangGenerator,
         SGLangEngineArgs,
         ServerArgs,
-        LMGenerateArgs,
     )
     from achatbot.common.session import Session
     from achatbot.common.types import SessionCtx

--- a/deploy/modal/src/llm/sglang/examples/generate.py
+++ b/deploy/modal/src/llm/sglang/examples/generate.py
@@ -125,8 +125,8 @@ async def run_async():
 
 
 achatbot_sglang_image = sglang_image.pip_install(
-    "achatbot[sglang]~=0.0.9.1.9",
-    extra_index_url="https://test.pypi.org/simple/",
+    "achatbot~=0.0.9.post1",
+    extra_index_url="https://pypi.org/simple/",
 )
 
 

--- a/deploy/modal/src/llm/tensorrt_llm/examples/generator.py
+++ b/deploy/modal/src/llm/tensorrt_llm/examples/generator.py
@@ -1,1 +1,0 @@
-# https://github.com/NVIDIA/TensorRT-LLM/blob/main/examples/run.py#L548

--- a/deploy/modal/src/llm/tensorrt_llm/examples/generator.py
+++ b/deploy/modal/src/llm/tensorrt_llm/examples/generator.py
@@ -1,0 +1,1 @@
+# https://github.com/NVIDIA/TensorRT-LLM/blob/main/examples/run.py#L548

--- a/deploy/modal/src/llm/trtllm/examples/generator.py
+++ b/deploy/modal/src/llm/trtllm/examples/generator.py
@@ -40,8 +40,8 @@ trtllm_image = (
 )
 
 achatbot_trtllm_image = trtllm_image.pip_install(
-    "achatbot[]~=0.0.9.1.9",
-    extra_index_url="https://test.pypi.org/simple/",
+    "achatbot~=0.0.9.post1",
+    extra_index_url="https://pypi.org/simple/",
 ).env(
     {
         "TLLM_LLMAPI_BUILD_CACHE": "1",

--- a/deploy/modal/src/llm/trtllm/examples/generator.py
+++ b/deploy/modal/src/llm/trtllm/examples/generator.py
@@ -1,0 +1,223 @@
+# https://github.com/NVIDIA/TensorRT-LLM/blob/main/examples/run.py#L548
+
+# https://nvidia.github.io/TensorRT-LLM/index.html (nice doc)
+"""
+NeMo -------------
+                  |
+HuggingFace ------
+                  |   convert                             build                    load
+Modelopt ---------  ----------> TensorRT-LLM Checkpoint --------> TensorRT Engine ------> TensorRT-LLM ModelRunner
+                  |
+JAX --------------
+                  |
+DeepSpeed --------
+"""
+
+import os
+import modal
+
+app_name = "qwen2.5-0.5B"
+
+app = modal.App("trtllm-generator")
+
+trtllm_image = (
+    # https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags
+    modal.Image.from_registry(
+        "nvidia/cuda:12.8.0-devel-ubuntu22.04",
+        add_python="3.10",
+    )
+    .apt_install(
+        "git", "git-lfs", "openmpi-bin", "libopenmpi-dev", "wget"
+    )  # OpenMPI for distributed communication
+    .pip_install(
+        "tensorrt-llm==0.17.0.post1",
+        # "pynvml<12",  # avoid breaking change to pynvml version API for tensorrt_llm
+        # "tensorrt==10.8.0.43",
+        pre=True,
+        extra_index_url="https://pypi.nvidia.com",
+    )
+    .env({})
+)
+
+MAX_BATCH_SIZE = 1024  # better throughput at larger batch sizes, limited by GPU RAM
+MODEL_ID = "Qwen/Qwen2.5-0.5B"
+
+HF_MODEL_DIR = "/root/models"
+hf_model_vol = modal.Volume.from_name("models", create_if_missing=True)
+TRT_MODEL_DIR = "/root/trt_models"
+trt_model_vol = modal.Volume.from_name("triton_trtllm_models", create_if_missing=True)
+
+
+@app.function(
+    gpu=os.getenv("IMAGE_GPU", "L4"),
+    cpu=2.0,
+    retries=0,
+    image=trtllm_image.env({"TORCH_CUDA_ARCH_LIST": "8.0 8.6 8.7 8.9 9.0"}),
+    volumes={
+        HF_MODEL_DIR: hf_model_vol,
+    },
+    timeout=1200,  # default 300s
+    scaledown_window=1200,
+    max_containers=100,
+)
+def run_sync():
+    """
+    https://nvidia.github.io/TensorRT-LLM/_modules/tensorrt_llm/llmapi/llm.html#LLM.generate
+    """
+    from tensorrt_llm import LLM, SamplingParams
+
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+    # https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.SamplingParams
+    sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+
+    # load hf model, convert to tensorrt, build tensorrt engine, load tensorrt engine
+    llm = LLM(model=MODEL_ID)
+
+    outputs = llm.generate(prompts, sampling_params, use_tqdm=False)
+
+    # Print the outputs.
+    for output in outputs:
+        print(output)
+
+
+@app.function(
+    gpu=os.getenv("IMAGE_GPU", "L4"),
+    cpu=2.0,
+    retries=0,
+    image=trtllm_image.env({"TORCH_CUDA_ARCH_LIST": "8.0 8.6 8.7 8.9 9.0"}),
+    volumes={
+        HF_MODEL_DIR: hf_model_vol,
+    },
+    timeout=1200,  # default 300s
+    scaledown_window=1200,
+    max_containers=100,
+)
+async def run_async_stream():
+    """
+    https://nvidia.github.io/TensorRT-LLM/_modules/tensorrt_llm/llmapi/llm.html#LLM.generate_async
+    """
+    from tensorrt_llm import LLM, SamplingParams
+
+    prompts = [
+        "Hello, my name is",
+        # "The president of the United States is",
+        # "The capital of France is",
+        # "The future of AI is",
+    ]
+    # https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.SamplingParams
+    sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=2, detokenize=False)
+
+    # load hf model, convert to tensorrt, build tensorrt engine, load tensorrt engine
+    llm = LLM(model=MODEL_ID)
+
+    for i, prompt in enumerate(prompts):
+        generator = llm.generate_async(prompt, sampling_params, streaming=True)
+        async for output in generator:
+            print(output)
+
+
+@app.function(
+    gpu=os.getenv("IMAGE_GPU", "L4"),
+    cpu=2.0,
+    retries=0,
+    image=trtllm_image.env({"TORCH_CUDA_ARCH_LIST": "8.0 8.6 8.7 8.9 9.0"}),
+    volumes={
+        HF_MODEL_DIR: hf_model_vol,
+    },
+    timeout=1200,  # default 300s
+    scaledown_window=1200,
+    max_containers=100,
+)
+async def run_async_batch_stream():
+    """
+    https://nvidia.github.io/TensorRT-LLM/_modules/tensorrt_llm/llmapi/llm.html#LLM.generate_async
+    """
+    import asyncio
+    import uuid
+
+    from tensorrt_llm import LLM, SamplingParams
+
+    # Prompts to generate
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    # Sampling parameters
+    sampling_params = SamplingParams(
+        temperature=0.8, top_p=0.95, max_tokens=2, detokenize=True, return_perf_metrics=True
+    )
+
+    # Load HF model, convert to TensorRT, build TensorRT engine, load TensorRT engine
+    llm = LLM(model=MODEL_ID)
+
+    lock = asyncio.Lock()
+
+    async def run_async_stream(llm, prompt, sampling_params, request_id=str(uuid.uuid4().hex)):
+        generator = llm.generate_async(prompt, sampling_params, streaming=True)
+        async for item in generator:
+            print(f"[{request_id}] tokenId: {item.outputs[0].token_ids[-1]} {item} ")
+            async with lock:
+                print(f"[{request_id}] {item}")
+                print(item.outputs[0].token_ids[-1])
+                # u can send this response to a request queue/channle
+
+    tasks = [
+        run_async_stream(llm, prompt, sampling_params, request_id=str(uuid.uuid4().hex))
+        for prompt in prompts
+    ]
+    await asyncio.gather(*tasks)
+
+
+@app.function(
+    gpu=os.getenv("IMAGE_GPU", "L4"),
+    cpu=2.0,
+    retries=0,
+    image=trtllm_image.env({"TORCH_CUDA_ARCH_LIST": "8.0 8.6 8.7 8.9 9.0"}),
+    volumes={
+        HF_MODEL_DIR: hf_model_vol,
+    },
+    timeout=1200,  # default 300s
+    scaledown_window=1200,
+    max_containers=100,
+)
+async def runner_stream():
+    """
+    https://nvidia.github.io/TensorRT-LLM/_modules/tensorrt_llm/llmapi/llm.html#LLM.generate_async
+    """
+    from tensorrt_llm import LLM, SamplingParams
+
+    prompts = [
+        "Hello, my name is",
+        # "The president of the United States is",
+        # "The capital of France is",
+        # "The future of AI is",
+    ]
+    # https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.SamplingParams
+    sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=2, detokenize=False)
+
+    # load hf model, convert to tensorrt, build tensorrt engine, load tensorrt engine
+    llm = LLM(model=MODEL_ID)
+
+    for i, prompt in enumerate(prompts):
+        generator = llm.generate_async(prompt, sampling_params, streaming=True)
+        async for output in generator:
+            print(output)
+
+
+"""
+# llmapi (LLM load hf model, convert to tensorrt, build tensorrt engine, load tensorrt engine)
+modal run src/llm/trtllm/examples/generator.py::run_sync (no stream | batch prompts processing | throughput)
+modal run src/llm/trtllm/examples/generator.py::run_async_stream (stream | single prompt async processing | latency)
+modal run src/llm/trtllm/examples/generator.py::run_async_batch_stream (stream | batch prompts async processing | latency+throughput) (multiple prompts/request or one prompt/request)
+
+# runner (load tensorrt engine to run generate)
+
+"""

--- a/deploy/modal/src/llm/trtllm/tts_spark/compile_model.py
+++ b/deploy/modal/src/llm/trtllm/tts_spark/compile_model.py
@@ -94,6 +94,13 @@ def trtllm_build(
 
 """
 modal run src/llm/trtllm/tts_spark/compile_model.py \
+    --app-name "qwen2.5-0.5B" \
+    --hf-repo-dir "Qwen/Qwen2.5-0.5B" \
+    --trt-dtype "bfloat16" \
+    --convert-other-args "" \
+    --compile-other-args "--max_batch_size 16 --max_num_tokens 32768"
+
+modal run src/llm/trtllm/tts_spark/compile_model.py \
     --app-name "tts-spark" \
     --hf-repo-dir "SparkAudio/Spark-TTS-0.5B/LLM" \
     --trt-dtype "bfloat16" \

--- a/deploy/modal/src/llm/vllm/examples/generate.py
+++ b/deploy/modal/src/llm/vllm/examples/generate.py
@@ -29,8 +29,8 @@ vllm_image = vllm_image.env(
 )
 
 achatbot_vllm_image = vllm_image.pip_install(
-    "achatbot[vllm]~=0.0.9.1.9",
-    extra_index_url="https://test.pypi.org/simple/",
+    "achatbot~=0.0.9.post1",
+    extra_index_url="https://pypi.org/simple/",
 )
 
 HF_MODEL_DIR = "/root/models"

--- a/deploy/modal/src/llm/vllm/examples/generate.py
+++ b/deploy/modal/src/llm/vllm/examples/generate.py
@@ -1,0 +1,148 @@
+import os
+import modal
+
+app = modal.App("vllm-generate")
+
+vllm_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install(
+        "vllm==0.7.3",
+        "huggingface_hub[hf_transfer]==0.26.2",
+        "flashinfer-python==0.2.0.post2",
+        extra_index_url="https://flashinfer.ai/whl/cu124/torch2.5",
+    )
+    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})  # faster model transfers
+)
+
+hf_cache_vol = modal.Volume.from_name("huggingface-cache", create_if_missing=True)
+
+# PP need close v1
+vllm_image = vllm_image.env(
+    {
+        "VLLM_USE_V1": os.getenv("VLLM_USE_V1", "1"),
+    }
+)
+
+
+HF_MODEL_DIR = "/root/models"
+hf_model_vol = modal.Volume.from_name("models", create_if_missing=True)
+VLLM_CACHE_DIR = "/root/.cache/vllm"
+vllm_cache_vol = modal.Volume.from_name("vllm-cache", create_if_missing=True)
+
+
+@app.function(
+    gpu=os.getenv("IMAGE_GPU", "L4"),
+    cpu=2.0,
+    retries=0,
+    image=vllm_image,
+    volumes={
+        HF_MODEL_DIR: hf_model_vol,
+        VLLM_CACHE_DIR: vllm_cache_vol,
+    },
+    timeout=1200,  # default 300s
+    scaledown_window=1200,
+    max_containers=100,
+)
+def run_sync():
+    from vllm import LLM, EngineArgs
+
+    engine = LLM(
+        model="/root/models/Qwen/Qwen2.5-0.5B",
+        # dtype="half",
+        # enforce_eager=True,
+    )
+
+    sampling_params = engine.get_default_sampling_params()
+    print(sampling_params)
+    sampling_params.n = 1
+    sampling_params.seed = 42
+    sampling_params.max_tokens = 2
+    sampling_params.temperature = 0.9
+    sampling_params.top_p = 1.0
+    sampling_params.top_k = 50
+    sampling_params.min_p = 0.0
+    # Penalizers
+    sampling_params.repetition_penalty = 1.1
+    sampling_params.min_tokens = 0
+    outputs = engine.generate(
+        "Hello, my name is",
+        sampling_params=sampling_params,
+    )
+    print(outputs)
+    i = 1
+    for part in outputs:
+        print(part)
+        if i == 3:
+            print("stopping")
+            break
+        i += 1
+
+
+@app.function(
+    gpu=os.getenv("IMAGE_GPU", "L4"),
+    cpu=2.0,
+    retries=0,
+    image=vllm_image,
+    volumes={
+        HF_MODEL_DIR: hf_model_vol,
+        VLLM_CACHE_DIR: vllm_cache_vol,
+    },
+    timeout=1200,  # default 300s
+    scaledown_window=1200,
+    max_containers=100,
+)
+async def run_async():
+    import asyncio
+    import uuid
+
+    from vllm import AsyncEngineArgs, AsyncLLMEngine, SamplingParams
+    # from vllm.engine.async_llm_engine import AsyncEngineArgs, AsyncLLMEngine
+
+    engine = AsyncLLMEngine.from_engine_args(
+        AsyncEngineArgs(
+            model="/root/models/Qwen/Qwen2.5-0.5B",
+            # dtype="half",
+            # enforce_eager=True,
+        )
+    )
+
+    sampling_params = SamplingParams(
+        n=1,
+        seed=42,
+        max_tokens=2,
+        temperature=0.9,
+        top_p=1.0,
+        top_k=50,
+        min_p=0.0,
+        # Penalizers
+        repetition_penalty=1.1,
+        min_tokens=0,
+    )
+    print(sampling_params)
+
+    outputs_generator = engine.generate(
+        "Hello, my name is", sampling_params=sampling_params, request_id=str(uuid.uuid4().hex)
+    )
+    i = 1
+    async for part in outputs_generator:
+        print(part)
+        """
+        RequestOutput(request_id=a80d0cce8c774cbaada1ae0bb993ddf5, prompt='Hello, my name is', prompt_token_ids=[9707, 11, 847, 829, 374], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text=' David', token_ids=[6798], cumulative_logprob=None, logprobs=None, finish_reason=None, stop_reason=None)], finished=False, metrics=None, lora_request=None, num_cached_tokens=None, multi_modal_placeholders={})
+        """
+        if part.outputs:
+            print(part.outputs[0].token_ids[-1])
+        if i == 3:
+            print("stopping")
+            break
+        i += 1
+
+
+"""
+modal run src/llm/vllm/examples/generate.py::run_sync (no stream)
+modal run src/llm/vllm/examples/generate.py::run_async (stream)
+"""
+
+
+# @app.local_entrypoint()
+# def main():
+#    run_sync.remote()

--- a/deploy/modal/src/llm/vllm/examples/generate.py
+++ b/deploy/modal/src/llm/vllm/examples/generate.py
@@ -11,7 +11,12 @@ vllm_image = (
         "flashinfer-python==0.2.0.post2",
         extra_index_url="https://flashinfer.ai/whl/cu124/torch2.5",
     )
-    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1"})  # faster model transfers
+    .env(
+        {
+            "HF_HUB_ENABLE_HF_TRANSFER": "1",
+            "TORCH_CUDA_ARCH_LIST": "8.0 8.6 8.7 8.9 9.0",
+        }
+    )  # faster model transfers
 )
 
 hf_cache_vol = modal.Volume.from_name("huggingface-cache", create_if_missing=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 name = "achatbot"
 #dynamic = ["version"]
 # todo
-version = "0.0.9"
+version = "0.0.9.1.7"
 authors = [{ name = "weedge", email = "weege007@gmail.com" }]
 maintainers = [{ name = "weedge", email = "weege007@gmail.com" }]
 description = "An open source chat bot for voice (and multimodal) assistants"
@@ -192,6 +192,7 @@ llm_personalai_proxy = ["geocoder~=1.38.1"]
 sglang = ["sglang[all]"]
 vllm = ["vllm"]
 transformers = ["transformers[torch]"]
+trtllm = ["tensorrt-llm~=0.17.0.post1"]
 
 
 # vision llm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,10 @@ librosa = ["librosa~=0.10.2.post1"]
 soundfile = ["soundfile~=0.12.1"]
 silero-vad = ["silero-vad~=5.1.2"]
 
+# llm engine
+sglang = ["sglang[all]"]
+vllm = ["vllm"]
+
 
 # diffusers DiT with quantizing model
 diffusers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 name = "achatbot"
 #dynamic = ["version"]
 # todo
-version = "0.0.9.1.9"
+version = "0.0.9.post1"
 authors = [{ name = "weedge", email = "weege007@gmail.com" }]
 maintainers = [{ name = "weedge", email = "weege007@gmail.com" }]
 description = "An open source chat bot for voice (and multimodal) assistants"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,7 @@ vad_recorder = ["achatbot[speech_vad]"]
 # if want to use other lib(cuda), see: https://github.com/abetlen/llama-cpp-python#installation-configuration
 llama_cpp = ["llama-cpp-python~=0.2.82"]
 llm_personalai_proxy = ["geocoder~=1.38.1"]
-sglang = ["sglang[all]"]
+sglang = ["sglang[all]~=0.4.4.post1"]
 vllm = ["vllm==0.7.3"]
 transformers = ["transformers[torch]"]
 trtllm = ["tensorrt-llm~=0.17.0.post1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,9 +190,13 @@ vad_recorder = ["achatbot[speech_vad]"]
 llama_cpp = ["llama-cpp-python~=0.2.82"]
 llm_personalai_proxy = ["geocoder~=1.38.1"]
 sglang = ["sglang[all]"]
-vllm = ["vllm"]
+vllm = ["vllm==0.7.3"]
 transformers = ["transformers[torch]"]
 trtllm = ["tensorrt-llm~=0.17.0.post1"]
+
+# llm backend
+# extra_index_url="https://flashinfer.ai/whl/cu124/torch2.5",
+flashinfer-python = ["flashinfer-python==0.2.0.post2"]
 
 
 # vision llm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,11 +192,12 @@ llm_personalai_proxy = ["geocoder~=1.38.1"]
 sglang = ["sglang[all]~=0.4.4.post1"]
 vllm = ["vllm==0.7.3"]
 transformers = ["transformers[torch]"]
+# --extra-index-url https://pypi.nvidia.com python3.10 and python3.12 | python3.11 unsupported
 trtllm = ["tensorrt-llm~=0.17.0.post1"]
 
 # llm backend
-# extra_index_url="https://flashinfer.ai/whl/cu124/torch2.5",
-flashinfer-python = ["flashinfer-python==0.2.0.post2"]
+# --extra-index-url "https://flashinfer.ai/whl/cu124/torch2.5",
+flashinfer-python = ["flashinfer-python~=0.2.3"]
 
 
 # vision llm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,10 +88,6 @@ librosa = ["librosa~=0.10.2.post1"]
 soundfile = ["soundfile~=0.12.1"]
 silero-vad = ["silero-vad~=5.1.2"]
 
-# llm engine
-sglang = ["sglang[all]"]
-vllm = ["vllm"]
-
 
 # diffusers DiT with quantizing model
 diffusers = [
@@ -187,11 +183,16 @@ rms_recorder = []
 vad_recorder = ["achatbot[speech_vad]"]
 
 # --------------------------------- llm --------------------------
+# llm engine
 # llm module tag -> pkgs
-# init  use cpu Pre-built Wheel to install, 
+# init use cpu Pre-built Wheel to install, 
 # if want to use other lib(cuda), see: https://github.com/abetlen/llama-cpp-python#installation-configuration
 llama_cpp = ["llama-cpp-python~=0.2.82"]
 llm_personalai_proxy = ["geocoder~=1.38.1"]
+sglang = ["sglang[all]"]
+vllm = ["vllm"]
+transformers = ["transformers[torch]"]
+
 
 # vision llm
 llm_transformers_manual_vision = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 name = "achatbot"
 #dynamic = ["version"]
 # todo
-version = "0.0.9.1.7"
+version = "0.0.9.1.9"
 authors = [{ name = "weedge", email = "weege007@gmail.com" }]
 maintainers = [{ name = "weedge", email = "weege007@gmail.com" }]
 description = "An open source chat bot for voice (and multimodal) assistants"
@@ -50,14 +50,14 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "requests~=2.32.3",
+    "requests",
     "apipeline~=0.1.32",
-    "python-dotenv~=1.0.1",
-    "pydub~=0.25.1",        # need install ffmpeg
-    "pillow~=10.4.0",
-    "aiohttp~=3.10.3",
+    "python-dotenv",
+    "pydub",             # need install ffmpeg
+    "pillow",
+    "aiohttp",
     "scipy",
-    "pyloudnorm~=0.1.1",
+    "pyloudnorm",
     "numpy>=1.22.0",
 ]
 
@@ -189,7 +189,7 @@ vad_recorder = ["achatbot[speech_vad]"]
 # if want to use other lib(cuda), see: https://github.com/abetlen/llama-cpp-python#installation-configuration
 llama_cpp = ["llama-cpp-python~=0.2.82"]
 llm_personalai_proxy = ["geocoder~=1.38.1"]
-sglang = ["sglang[all]~=0.4.4.post1"]
+sglang = ["sglang[all]"]
 vllm = ["vllm==0.7.3"]
 transformers = ["transformers[torch]"]
 # --extra-index-url https://pypi.nvidia.com python3.10 and python3.12 | python3.11 unsupported

--- a/src/common/interface.py
+++ b/src/common/interface.py
@@ -152,10 +152,10 @@ class IHallucination(ABC):
         raise NotImplementedError("must be implemented in the child class")
 
 
-class IMultimodalLlm(ABC):
+class ILlmGenerator(ABC):
     @abstractmethod
-    async def generate_tokens(self, session) -> AsyncGenerator[Any, None]:
-        """return tensor tokens async generator"""
+    async def generate(self, session, **kwargs) -> AsyncGenerator[int, None]:
+        """return token ids async generator"""
         raise NotImplementedError("must be implemented in the child class")
 
 

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -11,6 +11,7 @@ from typing import (
     List,
     Any,
     Mapping,
+    Union,
 )
 import os
 from pathlib import Path
@@ -287,11 +288,14 @@ class LLamcppLLMArgs:
     flash_attn: bool = False
     # llm
     llm_prompt_tpl: str = "<|user|>\n{%s}<|end|>\n<|assistant|>"
-    llm_stop: Optional[List[str]] = None
+    llm_stop: Optional[Union[int, List[str]]] = field(default_factory=list)
+    llm_stop_ids: Optional[Union[int, List[int]]] = field(default_factory=list)
     llm_max_tokens: int = 1024
     llm_temperature: float = 0.8
     llm_top_p: float = 0.95
+    llm_min_p: float = 0.05
     llm_top_k: int = 40
+    llm_seed: Optional[int] = None
     # repeat penalty
     llm_repeat_penalty: float = 1.0
     llm_repeat_last_n: int = 64

--- a/src/common/types.py
+++ b/src/common/types.py
@@ -292,6 +292,10 @@ class LLamcppLLMArgs:
     llm_temperature: float = 0.8
     llm_top_p: float = 0.95
     llm_top_k: int = 40
+    # repeat penalty
+    llm_repeat_penalty: float = 1.0
+    llm_repeat_last_n: int = 64
+    # chat stream
     llm_stream: bool = False
     llm_chat_system: str = ""
     # "none" | "auto" | dict function like this: { "type": "function", "function": { "name": "get_current_weather" } },

--- a/src/core/llm/__init__.py
+++ b/src/core/llm/__init__.py
@@ -201,16 +201,14 @@ class LLMEnvInit:
     def get_llm_vllm_generator_args() -> dict:
         from src.core.llm.vllm.generator import VllmEngineArgs, AsyncEngineArgs
 
-        kwargs = (
-            VllmEngineArgs(
-                serv_args=AsyncEngineArgs(
-                    model=os.getenv(
-                        "LLM_MODEL_NAME_OR_PATH", os.path.join(MODELS_DIR, "Qwen/Qwen2.5-0.5B")
-                    )
-                ).__dict__,
-                gen_args=LLMEnvInit._get_llm_generate_args(),
+        kwargs = VllmEngineArgs(
+            serv_args=AsyncEngineArgs(
+                model=os.getenv(
+                    "LLM_MODEL_NAME_OR_PATH", os.path.join(MODELS_DIR, "Qwen/Qwen2.5-0.5B")
+                )
             ).__dict__,
-        )
+            gen_args=LLMEnvInit._get_llm_generate_args(),
+        ).__dict__
         return kwargs
 
     @staticmethod

--- a/src/core/llm/base.py
+++ b/src/core/llm/base.py
@@ -1,9 +1,10 @@
 import re
 
+from src.common.interface import ILlm
 from src.common.factory import EngineClass
 
 
-class BaseLLM(EngineClass):
+class BaseLLM(EngineClass, ILlm):
     def model_name(self):
         if hasattr(self.args, "model_name"):
             return self.args.model_name
@@ -20,3 +21,17 @@ class BaseLLM(EngineClass):
             if len(matches) == 0:
                 return -1
             return content.index(matches[len(matches) - 1])
+
+    def generate(self, session, **kwargs):
+        """
+        generate text or tokens with stream iterator
+        - local llm cpu/gpu bind
+        - api llm io bind
+        """
+        pass
+
+    def chat_completion(self, session, **kwargs):
+        pass
+
+    def count_tokens(self, text: str | bytes):
+        pass

--- a/src/core/llm/base.py
+++ b/src/core/llm/base.py
@@ -4,7 +4,7 @@ from src.common.interface import ILlm
 from src.common.factory import EngineClass
 
 
-class BaseLLM(EngineClass, ILlm):
+class BaseLLM(EngineClass):
     def model_name(self):
         if hasattr(self.args, "model_name"):
             return self.args.model_name
@@ -21,17 +21,3 @@ class BaseLLM(EngineClass, ILlm):
             if len(matches) == 0:
                 return -1
             return content.index(matches[len(matches) - 1])
-
-    def generate(self, session, **kwargs):
-        """
-        generate text or tokens with stream iterator
-        - local llm cpu/gpu bind
-        - api llm io bind
-        """
-        pass
-
-    def chat_completion(self, session, **kwargs):
-        pass
-
-    def count_tokens(self, text: str | bytes):
-        pass

--- a/src/core/llm/llamacpp/generator.py
+++ b/src/core/llm/llamacpp/generator.py
@@ -1,0 +1,41 @@
+from ..llamacpp import LLamacppLLM
+
+from src.common.session import Session
+
+
+class LlamacppGenerator(LLamacppLLM):
+    """
+    token_ids -> llm generate stream -> token_ids
+    """
+
+    TAG = "llm_llamacpp_generator"
+
+    def generate(self, session: Session, **kwargs):
+        assert session.ctx.state["token_ids"] is not None
+        assert isinstance(session.ctx.state["token_ids"], list)
+        token_ids = session.ctx.state["token_ids"]
+        generator = self.model.generate(
+            token_ids,
+            temp=kwargs.get("temperature", self.args.llm_temperature),
+            top_k=kwargs.get("top_k", self.args.llm_top_k),
+            top_p=kwargs.get("top_p", self.args.llm_top_p),
+            repeat_penalty=kwargs.get("repeat_penalty", self.args.llm_repeat_penalty),
+        )
+        for token_id in generator:
+            yield token_id
+
+
+"""
+MODEL=./models/Qwen/Qwen2.5-0.5B python -m src.core.llm.llamacpp.generator 
+"""
+if __name__ == "__main__":
+    from src.common.types import SessionCtx
+    import uuid
+    import os
+
+    generator = LlamacppGenerator()
+
+    session = Session(**SessionCtx(str(uuid.uuid4().hex)).__dict__)
+    gen_iter = generator.generate(session, max_new_tokens=3)
+    for token_id in gen_iter:
+        print(token_id)

--- a/src/core/llm/llamacpp/generator.py
+++ b/src/core/llm/llamacpp/generator.py
@@ -19,17 +19,32 @@ class LlamacppGenerator(LLamacppLLM):
         # AR generate model
         generator = self.model.generate(
             token_ids,
-            temp=kwargs.get("temperature", self.args.llm_temperature),
-            top_k=kwargs.get("top_k", self.args.llm_top_k),
-            top_p=kwargs.get("top_p", self.args.llm_top_p),
-            min_p=kwargs.get("min_p", self.args.llm_min_p),
-            repeat_penalty=kwargs.get("repetition_penalty", self.args.llm_repeat_penalty),
+            temp=kwargs.get("temperature", self.args.llm_temperature)
+            if kwargs.get("temperature", self.args.llm_temperature)
+            else 0.80,
+            top_k=kwargs.get("top_k", self.args.llm_top_k)
+            if kwargs.get("top_k", self.args.llm_top_k)
+            else 50,
+            top_p=kwargs.get("top_p", self.args.llm_top_p)
+            if kwargs.get("top_p", self.args.llm_top_p)
+            else 0.9,
+            min_p=kwargs.get("min_p", self.args.llm_min_p)
+            if kwargs.get("min_p", self.args.llm_min_p)
+            else 0.0,
+            repeat_penalty=kwargs.get("repetition_penalty", self.args.llm_repeat_penalty)
+            if kwargs.get("repetition_penalty", self.args.llm_repeat_penalty)
+            else 1.0,
         )
 
-        # todo: cache
+        # todo: cache for multi generate on the same session,
+        # once generate like tts(speech lm) don't use cache
 
         stop_ids = kwargs.get("stop_ids", self.args.llm_stop_ids)
-        max_new_tokens = kwargs.get("max_new_tokens", self.args.llm_max_tokens)
+        max_new_tokens = (
+            kwargs.get("max_new_tokens", self.args.llm_max_tokens)
+            if kwargs.get("max_new_tokens", self.args.llm_max_tokens)
+            else 20
+        )
         if max_new_tokens > self.args.n_ctx - len(token_ids):
             max_new_tokens = self.args.n_ctx - len(token_ids)
         token_cn = 0

--- a/src/core/llm/llamacpp/generator.py
+++ b/src/core/llm/llamacpp/generator.py
@@ -1,5 +1,6 @@
-from ..llamacpp import LLamacppLLM
+import logging
 
+from . import LLamacppLLM
 from src.common.session import Session
 
 
@@ -14,28 +15,65 @@ class LlamacppGenerator(LLamacppLLM):
         assert session.ctx.state["token_ids"] is not None
         assert isinstance(session.ctx.state["token_ids"], list)
         token_ids = session.ctx.state["token_ids"]
+        # https://llama-cpp-python.readthedocs.io/en/latest/api-reference/#llama_cpp.Llama.generate
+        # AR generate model
         generator = self.model.generate(
             token_ids,
             temp=kwargs.get("temperature", self.args.llm_temperature),
             top_k=kwargs.get("top_k", self.args.llm_top_k),
             top_p=kwargs.get("top_p", self.args.llm_top_p),
-            repeat_penalty=kwargs.get("repeat_penalty", self.args.llm_repeat_penalty),
+            min_p=kwargs.get("min_p", self.args.llm_min_p),
+            repeat_penalty=kwargs.get("repetition_penalty", self.args.llm_repeat_penalty),
         )
+
+        # todo: cache
+
+        stop_ids = kwargs.get("stop_ids", self.args.llm_stop_ids)
+        max_new_tokens = kwargs.get("max_new_tokens", self.args.llm_max_tokens)
+        if max_new_tokens > self.args.n_ctx - len(token_ids):
+            max_new_tokens = self.args.n_ctx - len(token_ids)
+        token_cn = 0
         for token_id in generator:
+            if token_cn >= max_new_tokens:
+                break
+            token_cn += 1
             yield token_id
+            if token_id in stop_ids:
+                break
 
 
 """
-MODEL=./models/Qwen/Qwen2.5-0.5B python -m src.core.llm.llamacpp.generator 
+MODEL=./models/qwen2.5-0.5b-instruct-q8_0.gguf \
+    TOKENIZER_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
+    python -m src.core.llm.llamacpp.generator 
 """
 if __name__ == "__main__":
-    from src.common.types import SessionCtx
     import uuid
     import os
+    import time
 
-    generator = LlamacppGenerator()
+    from transformers import AutoTokenizer
+    from src.common.types import SessionCtx
+    from src.common.types import LLamcppLLMArgs
+
+    logging.basicConfig(level=logging.INFO)
+
+    tokenizer_path = os.getenv("TOKENIZER_PATH", "./models/Qwen/Qwen2.5-0.5B-Instruct")
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
+
+    model_path = os.getenv("MODEL", "./models/qwen2.5-0.5b-instruct-q8_0.gguf")
+    generator = LlamacppGenerator(**LLamcppLLMArgs(model_path=model_path).__dict__)
 
     session = Session(**SessionCtx(str(uuid.uuid4().hex)).__dict__)
-    gen_iter = generator.generate(session, max_new_tokens=3)
+    session.ctx.state["token_ids"] = tokenizer.encode("hello, my name is")
+    # test max_new_tokens>n_ctx-len(token_ids)
+    gen_iter = generator.generate(session, max_new_tokens=100, stop_ids=[13])
+    start_time = time.perf_counter()
+    first = True
     for token_id in gen_iter:
-        print(token_id)
+        if first:
+            ttft = time.perf_counter() - start_time
+            logging.info(f"generate TTFT time: {ttft} s")
+            first = False
+        gen_text = tokenizer.decode(token_id)
+        print(token_id, gen_text)

--- a/src/core/llm/nexa.py
+++ b/src/core/llm/nexa.py
@@ -1,0 +1,1 @@
+# the same as llamacpp

--- a/src/core/llm/sglang/generator.py
+++ b/src/core/llm/sglang/generator.py
@@ -39,18 +39,19 @@ class SGlangGenerator(BaseLLM, ILlmGenerator):
         # https://docs.sglang.ai/backend/sampling_params.html
         sampling_params = {
             "n": 1,  # number of samples to generate
-            "max_new_tokens": kwargs.get("max_new_tokens", self.gen_args.lm_gen_max_new_tokens),
-            "temperature": kwargs.get("temperature", self.gen_args.lm_gen_temperature),
-            "top_p": kwargs.get("top_p", self.gen_args.lm_gen_top_p),
-            "top_k": kwargs.get("top_k", self.gen_args.lm_gen_top_k),
-            "min_p": kwargs.get("min_p", self.gen_args.lm_gen_min_p),
+            "max_new_tokens": kwargs.get("max_new_tokens")
+            if kwargs.get("max_new_tokens")
+            else self.gen_args.lm_gen_max_new_tokens,
+            "temperature": kwargs.get("temperature") or self.gen_args.lm_gen_temperature,
+            "top_p": kwargs.get("top_p") or self.gen_args.lm_gen_top_p,
+            "top_k": kwargs.get("top_k") or self.gen_args.lm_gen_top_k,
+            "min_p": kwargs.get("min_p") or self.gen_args.lm_gen_min_p,
             # Penalizers
-            "repetition_penalty": kwargs.get(
-                "repetition_penalty", self.gen_args.lm_gen_repetition_penalty
-            ),
-            "min_new_tokens": kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new_tokens),
-            "stop_token_ids": kwargs.get("stop_ids", self.gen_args.lm_gen_stop_ids),
-            "stop": kwargs.get("stop_tokens", self.gen_args.lm_gen_stops),
+            "repetition_penalty": kwargs.get("repetition_penalty")
+            or self.gen_args.lm_gen_repetition_penalty,
+            "min_new_tokens": kwargs.get("min_new_tokens") or self.gen_args.lm_gen_min_new_tokens,
+            "stop_token_ids": kwargs.get("stop_ids") or self.gen_args.lm_gen_stop_ids,
+            "stop": kwargs.get("stop_tokens") or self.gen_args.lm_gen_stops,
         }
         obj = GenerateReqInput(
             input_ids=token_ids,

--- a/src/core/llm/sglang/generator.py
+++ b/src/core/llm/sglang/generator.py
@@ -47,6 +47,8 @@ class SGlangGenerator:
                 "repetition_penalty", self.gen_args.lm_gen_repetition_penalty
             ),
             "min_new_tokens": kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new_tokens),
+            "stop_token_ids": kwargs.get("stop_ids", self.gen_args.lm_gen_stop_ids),
+            "stop": kwargs.get("stop_tokens", self.gen_args.lm_gen_stops),
         }
         obj = GenerateReqInput(
             input_ids=token_ids,
@@ -66,13 +68,13 @@ class SGlangGenerator:
 
 """
 python -m src.core.llm.sglang.generator --model-path ./models/Qwen/Qwen2.5-0.5B
+python -m src.core.llm.sglang.generator --model-path ./models/Qwen/Qwen2.5-0.5B-Instruct
 """
 if __name__ == "__main__":
     from src.common.types import SessionCtx
     import uuid
     import asyncio
     from transformers import AutoTokenizer
-
 
     parser = argparse.ArgumentParser()
     ServerArgs.add_cli_args(parser)

--- a/src/core/llm/sglang/generator.py
+++ b/src/core/llm/sglang/generator.py
@@ -1,0 +1,90 @@
+import argparse
+import logging
+
+try:
+    from sglang import Engine
+    from src.types.llm.sglang import SGLangEngineArgs, ServerArgs, LMGenerateArgs
+    from sglang.srt.managers.io_struct import GenerateReqInput
+except ModuleNotFoundError as e:
+    logging.error(f"Exception: {e}")
+    logging.error("you need to `pip install achatbot[sglang]`")
+    raise Exception(f"Missing module: {e}")
+
+from src.common.session import Session
+
+
+class SGlangGenerator:
+    """
+    token_ids -> llm generate stream -> token_ids
+    use sglang llm engine frontend asyncio api to generate token_ids
+    https://docs.sglang.ai/backend/offline_engine_api.html
+    todo: maybe use sglang llm engine backend method to generate token_ids
+    """
+
+    TAG = "llm_sglang_generator"
+
+    def __init__(self, **kwargs):
+        self.args = SGLangEngineArgs(**kwargs)
+        self.gen_args = LMGenerateArgs(**self.args.gen_args)
+        self.serv_args = ServerArgs(**self.args.serv_args)
+        self.engine = Engine(**self.serv_args.__dict__)
+
+    async def generate(self, session: Session, **kwargs):
+        assert session.ctx.state["token_ids"] is not None
+        assert isinstance(session.ctx.state["token_ids"], list)
+        token_ids = session.ctx.state["token_ids"]
+
+        # https://docs.sglang.ai/backend/sampling_params.html
+        sampling_params = {
+            "n": 1,  # number of samples to generate
+            "max_new_tokens": kwargs.get("max_new_tokens", self.gen_args.lm_gen_max_new_tokens),
+            "temperature": kwargs.get("temperature", self.gen_args.lm_gen_temperature),
+            "top_p": kwargs.get("top_p", self.gen_args.lm_gen_top_p),
+            "top_k": kwargs.get("top_k", self.gen_args.lm_gen_top_k),
+            "min_p": kwargs.get("min_p", self.gen_args.lm_gen_min_p),
+            # Penalizers
+            "repetition_penalty": kwargs.get(
+                "repetition_penalty", self.gen_args.lm_gen_repetition_penalty
+            ),
+            "min_new_tokens": kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new_tokens),
+        }
+        obj = GenerateReqInput(
+            input_ids=token_ids,
+            sampling_params=sampling_params,
+            rid=session.ctx.client_id,
+            stream=True,
+            return_logprob=True,
+        )
+        iterator = self.engine.tokenizer_manager.generate_request(obj, None)
+
+        async for part in iterator:
+            meta_info = part["meta_info"]
+            if "output_token_logprobs" in meta_info and len(meta_info["output_token_logprobs"]) > 0:
+                token_id = meta_info["output_token_logprobs"][-1][1]
+                yield token_id
+
+
+"""
+python -m src.core.llm.sglang.generator --model-path ./models/Qwen/Qwen2.5-0.5B
+"""
+if __name__ == "__main__":
+    from src.common.types import SessionCtx
+    import uuid
+    import asyncio
+
+    parser = argparse.ArgumentParser()
+    ServerArgs.add_cli_args(parser)
+    args = parser.parse_args()
+    server_args = ServerArgs.from_cli_args(args)
+    generator = SGlangGenerator(
+        **SGLangEngineArgs(
+            serv_args=server_args.__dict__,
+        ).__dict__
+    )
+
+    async def run():
+        session = Session(**SessionCtx(str(uuid.uuid4().hex)).__dict__)
+        async for token_id in generator.generate(session, max_new_tokens=3):
+            print(token_id)
+
+    asyncio.run(run())

--- a/src/core/llm/sglang/generator.py
+++ b/src/core/llm/sglang/generator.py
@@ -18,7 +18,7 @@ class SGlangGenerator:
     token_ids -> llm generate stream -> token_ids
     use sglang llm engine frontend asyncio api to generate token_ids
     https://docs.sglang.ai/backend/offline_engine_api.html
-    todo: maybe use sglang llm engine backend method to generate token_ids
+    todo: maybe use sglang llm engine backend runtime method to generate token_ids
     """
 
     TAG = "llm_sglang_generator"
@@ -71,6 +71,8 @@ if __name__ == "__main__":
     from src.common.types import SessionCtx
     import uuid
     import asyncio
+    from transformers import AutoTokenizer
+
 
     parser = argparse.ArgumentParser()
     ServerArgs.add_cli_args(parser)
@@ -82,8 +84,11 @@ if __name__ == "__main__":
         ).__dict__
     )
 
+    tokenizer = AutoTokenizer.from_pretrained(server_args.model_path)
+
     async def run():
         session = Session(**SessionCtx(str(uuid.uuid4().hex)).__dict__)
+        session.ctx.state["token_ids"] = tokenizer.encode("hello, my name is")
         async for token_id in generator.generate(session, max_new_tokens=3):
             print(token_id)
 

--- a/src/core/llm/sglang/generator.py
+++ b/src/core/llm/sglang/generator.py
@@ -10,10 +10,11 @@ except ModuleNotFoundError as e:
     logging.error("you need to `pip install achatbot[sglang]`")
     raise Exception(f"Missing module: {e}")
 
+from src.core.llm.base import BaseLLM
 from src.common.session import Session
 
 
-class SGlangGenerator:
+class SGlangGenerator(BaseLLM):
     """
     token_ids -> llm generate stream -> token_ids
     use sglang llm engine frontend asyncio api to generate token_ids

--- a/src/core/llm/tensorrt_llm/generator.py
+++ b/src/core/llm/tensorrt_llm/generator.py
@@ -10,11 +10,12 @@ except ModuleNotFoundError as e:
     logging.error("you need to `pip install achatbot[trtllm]`")
     raise Exception(f"Missing module: {e}")
 
+from src.common.interface import ILlmGenerator
 from src.core.llm.base import BaseLLM
 from src.common.session import Session
 
 
-class TrtLLMGenerator(BaseLLM):
+class TrtLLMGenerator(BaseLLM, ILlmGenerator):
     """
     token_ids -> llm generate stream -> token_ids
     use trtllm engine frontend asyncio api to generate token_ids
@@ -94,6 +95,7 @@ if __name__ == "__main__":
     import uuid
     import os
     import asyncio
+    import time
     from transformers import AutoTokenizer
 
     model = os.getenv("MODEL", "Qwen/Qwen2.5-0.5B")
@@ -105,7 +107,14 @@ if __name__ == "__main__":
     async def run():
         session = Session(**SessionCtx(str(uuid.uuid4().hex)).__dict__)
         session.ctx.state["token_ids"] = tokenizer.encode("hello, my name is")
+        start_time = time.perf_counter()
+        first = True
         async for token_id in generator.generate(session, max_new_tokens=3):
-            print(token_id)
+            if first:
+                ttft = time.perf_counter() - start_time
+                logging.info(f"generate TTFT time: {ttft} s")
+                first = False
+            gen_text = tokenizer.decode(token_id)
+            print(token_id, gen_text)
 
     asyncio.run(run())

--- a/src/core/llm/tensorrt_llm/generator.py
+++ b/src/core/llm/tensorrt_llm/generator.py
@@ -58,7 +58,9 @@ class TrtLLMGenerator:
                 self.gen_args.lm_gen_repetition_penalty,
             ),
             min_tokens=kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new),
-            detokenize=True,
+            stop_token_ids=kwargs.get("stop_ids", self.gen_args.lm_gen_stop_ids),
+            stop=kwargs.get("stop_tokens", self.gen_args.lm_gen_stops),
+            detokenize=False,
         )
         # https://nvidia.github.io/TensorRT-LLM/_modules/tensorrt_llm/llmapi/llm.html#LLM.generate_async
         generator = self.engine.generate_async(

--- a/src/core/llm/tensorrt_llm/generator.py
+++ b/src/core/llm/tensorrt_llm/generator.py
@@ -40,7 +40,7 @@ class TrtLLMGenerator:
         assert isinstance(session.ctx.state["token_ids"], list)
         token_ids = session.ctx.state["token_ids"]
 
-        # https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.SamplingParams
+        # https://github.com/NVIDIA/TensorRT-LLM/blob/v0.17.0/tensorrt_llm/sampling_params.py
         sampling_params = SamplingParams(
             n=1,
             seed=kwargs.get("seed", self.gen_args.lm_gen_seed),
@@ -51,13 +51,14 @@ class TrtLLMGenerator:
             temperature=kwargs.get("temperature", self.gen_args.lm_gen_temperature),
             top_p=kwargs.get("top_p", self.gen_args.lm_gen_top_p),
             top_k=kwargs.get("top_k", self.gen_args.lm_gen_top_k),
-            min_p=kwargs.get("min_p", self.gen_args.lm_gen_min_p),
+            # min_p need version > 0.17.0
+            # min_p=kwargs.get("min_p", self.gen_args.lm_gen_min_p),
             # Penalizers,
             repetition_penalty=kwargs.get(
                 "repetition_penalty",
                 self.gen_args.lm_gen_repetition_penalty,
             ),
-            min_tokens=kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new),
+            min_tokens=kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new_tokens),
             stop_token_ids=kwargs.get("stop_ids", self.gen_args.lm_gen_stop_ids),
             stop=kwargs.get("stop_tokens", self.gen_args.lm_gen_stops),
             detokenize=False,
@@ -66,6 +67,7 @@ class TrtLLMGenerator:
         generator = self.engine.generate_async(
             inputs=token_ids,
             sampling_params=sampling_params,
+            streaming=True,
         )
         async for part in generator:
             if part.outputs:
@@ -96,7 +98,7 @@ if __name__ == "__main__":
 
     model = os.getenv("MODEL", "Qwen/Qwen2.5-0.5B")
     generator = TrtLLMGenerator(
-        **TensorRTLLMEngineArgs(serv_args=LlmArgs(model=model).__dict__).__dict__,
+        **TensorRTLLMEngineArgs(serv_args=LlmArgs(model=model).to_dict()).__dict__,
     )
     tokenizer = AutoTokenizer.from_pretrained(model)
 

--- a/src/core/llm/tensorrt_llm/generator.py
+++ b/src/core/llm/tensorrt_llm/generator.py
@@ -10,11 +10,11 @@ except ModuleNotFoundError as e:
     logging.error("you need to `pip install achatbot[trtllm]`")
     raise Exception(f"Missing module: {e}")
 
+from src.core.llm.base import BaseLLM
 from src.common.session import Session
-from src.common.device_cuda import CUDAInfo
 
 
-class TrtLLMGenerator:
+class TrtLLMGenerator(BaseLLM):
     """
     token_ids -> llm generate stream -> token_ids
     use trtllm engine frontend asyncio api to generate token_ids

--- a/src/core/llm/tensorrt_llm/generator.py
+++ b/src/core/llm/tensorrt_llm/generator.py
@@ -1,7 +1,6 @@
 import logging
 import uuid
 
-
 try:
     from src.types.llm.tensorrt_llm import TensorRTLLMEngineArgs, LMGenerateArgs, LlmArgs
     from tensorrt_llm import LLM, SamplingParams
@@ -44,24 +43,19 @@ class TrtLLMGenerator(BaseLLM, ILlmGenerator):
         # https://github.com/NVIDIA/TensorRT-LLM/blob/v0.17.0/tensorrt_llm/sampling_params.py
         sampling_params = SamplingParams(
             n=1,
-            seed=kwargs.get("seed", self.gen_args.lm_gen_seed),
-            max_tokens=kwargs.get(
-                "max_new_tokens",
-                self.gen_args.lm_gen_max_new_tokens,
-            ),
-            temperature=kwargs.get("temperature", self.gen_args.lm_gen_temperature),
-            top_p=kwargs.get("top_p", self.gen_args.lm_gen_top_p),
-            top_k=kwargs.get("top_k", self.gen_args.lm_gen_top_k),
+            seed=kwargs.get("seed") or self.gen_args.lm_gen_seed,
+            max_tokens=kwargs.get("max_new_tokens") or self.gen_args.lm_gen_max_new_tokens,
+            temperature=kwargs.get("temperature") or self.gen_args.lm_gen_temperature,
+            top_p=kwargs.get("top_p") or self.gen_args.lm_gen_top_p,
+            top_k=kwargs.get("top_k") or self.gen_args.lm_gen_top_k,
             # min_p need version > 0.17.0
-            # min_p=kwargs.get("min_p", self.gen_args.lm_gen_min_p),
+            # min_p=kwargs.get("min_p") or self.gen_args.lm_gen_min_p,
             # Penalizers,
-            repetition_penalty=kwargs.get(
-                "repetition_penalty",
-                self.gen_args.lm_gen_repetition_penalty,
-            ),
-            min_tokens=kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new_tokens),
-            stop_token_ids=kwargs.get("stop_ids", self.gen_args.lm_gen_stop_ids),
-            stop=kwargs.get("stop_tokens", self.gen_args.lm_gen_stops),
+            repetition_penalty=kwargs.get("repetition_penalty")
+            or self.gen_args.lm_gen_repetition_penalty,
+            min_tokens=kwargs.get("min_new_tokens") or self.gen_args.lm_gen_min_new_tokens,
+            stop_token_ids=kwargs.get("stop_ids") or self.gen_args.lm_gen_stop_ids,
+            stop=kwargs.get("stop_tokens") or self.gen_args.lm_gen_stops,
             detokenize=False,
         )
         # https://nvidia.github.io/TensorRT-LLM/_modules/tensorrt_llm/llmapi/llm.html#LLM.generate_async

--- a/src/core/llm/tensorrt_llm/generator.py
+++ b/src/core/llm/tensorrt_llm/generator.py
@@ -1,0 +1,1 @@
+# https://github.com/NVIDIA/TensorRT-LLM/blob/main/examples/run.py#L548

--- a/src/core/llm/tensorrt_llm/generator.py
+++ b/src/core/llm/tensorrt_llm/generator.py
@@ -1,1 +1,107 @@
-# https://github.com/NVIDIA/TensorRT-LLM/blob/main/examples/run.py#L548
+import logging
+import uuid
+
+
+try:
+    from src.types.llm.tensorrt_llm import TensorRTLLMEngineArgs, LMGenerateArgs, LlmArgs
+    from tensorrt_llm import LLM, SamplingParams
+except ModuleNotFoundError as e:
+    logging.error(f"Exception: {e}")
+    logging.error("you need to `pip install achatbot[trtllm]`")
+    raise Exception(f"Missing module: {e}")
+
+from src.common.session import Session
+from src.common.device_cuda import CUDAInfo
+
+
+class TrtLLMGenerator:
+    """
+    token_ids -> llm generate stream -> token_ids
+    use trtllm engine frontend asyncio api to generate token_ids
+    https://nvidia.github.io/TensorRT-LLM/_modules/tensorrt_llm/llmapi/llm.html#LLM.generate_async
+    """
+
+    TAG = "llm_trtllm_generator"
+
+    def __init__(self, **kwargs):
+        self.args = TensorRTLLMEngineArgs(**kwargs)
+        self.gen_args = LMGenerateArgs(**self.args.gen_args)
+        # https://github.com/NVIDIA/TensorRT-LLM/blob/v0.17.0/tensorrt_llm/llmapi/llm_utils.py#L368
+        self.serv_args = LlmArgs.from_kwargs(**self.args.serv_args)
+        # https://nvidia.github.io/TensorRT-LLM/_modules/tensorrt_llm/llmapi/llm.html#LLM.__init__
+        # Load HF model, convert to TensorRT, build TensorRT engine, load TensorRT engine
+        self.engine = LLM(**self.serv_args.to_dict())
+
+    async def generate(self, session: Session, **kwargs):
+        """
+        Generate new tokens using the LLM model.
+        """
+        assert session.ctx.state["token_ids"] is not None
+        assert isinstance(session.ctx.state["token_ids"], list)
+        token_ids = session.ctx.state["token_ids"]
+
+        # https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.SamplingParams
+        sampling_params = SamplingParams(
+            n=1,
+            seed=kwargs.get("seed", self.gen_args.lm_gen_seed),
+            max_tokens=kwargs.get(
+                "max_new_tokens",
+                self.gen_args.lm_gen_max_new_tokens,
+            ),
+            temperature=kwargs.get("temperature", self.gen_args.lm_gen_temperature),
+            top_p=kwargs.get("top_p", self.gen_args.lm_gen_top_p),
+            top_k=kwargs.get("top_k", self.gen_args.lm_gen_top_k),
+            min_p=kwargs.get("min_p", self.gen_args.lm_gen_min_p),
+            # Penalizers,
+            repetition_penalty=kwargs.get(
+                "repetition_penalty",
+                self.gen_args.lm_gen_repetition_penalty,
+            ),
+            min_tokens=kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new),
+            detokenize=True,
+        )
+        # https://nvidia.github.io/TensorRT-LLM/_modules/tensorrt_llm/llmapi/llm.html#LLM.generate_async
+        generator = self.engine.generate_async(
+            inputs=token_ids,
+            sampling_params=sampling_params,
+        )
+        async for part in generator:
+            if part.outputs:
+                token_id = part.outputs[0].token_ids[-1]
+                yield token_id
+
+
+class TrtLLMRunnerGenerator:
+    """
+    token_ids -> llm generate stream -> token_ids
+    use trtllm engine runtime runner to generate token_ids
+    - https://nvidia.github.io/TensorRT-LLM/python-api/tensorrt_llm.runtime.html#tensorrt_llm.runtime.ModelRunner
+    - https://nvidia.github.io/TensorRT-LLM/python-api/tensorrt_llm.runtime.html#tensorrt_llm.runtime.ModelRunnerCpp
+    """
+
+    TAG = "llm_trtllm_runner_generator"
+
+
+"""
+MODEL=./models/Qwen/Qwen2.5-0.5B python -m src.core.llm.tensorrt_llm.generator 
+"""
+if __name__ == "__main__":
+    from src.common.types import SessionCtx
+    import uuid
+    import os
+    import asyncio
+    from transformers import AutoTokenizer
+
+    model = os.getenv("MODEL", "Qwen/Qwen2.5-0.5B")
+    generator = TrtLLMGenerator(
+        **TensorRTLLMEngineArgs(serv_args=LlmArgs(model=model).__dict__).__dict__,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(model)
+
+    async def run():
+        session = Session(**SessionCtx(str(uuid.uuid4().hex)).__dict__)
+        session.ctx.state["token_ids"] = tokenizer.encode("hello, my name is")
+        async for token_id in generator.generate(session, max_new_tokens=3):
+            print(token_id)
+
+    asyncio.run(run())

--- a/src/core/llm/transformers/generator.py
+++ b/src/core/llm/transformers/generator.py
@@ -1,0 +1,105 @@
+import logging
+from threading import Thread
+
+
+try:
+    import torch
+    from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+
+except ModuleNotFoundError as e:
+    logging.error(f"Exception: {e}")
+    logging.error(
+        "In order to use TTS spark, you need to `pip install achatbot[llm_transformers_manual_speech_spark]`,"
+    )
+    raise Exception(f"Missing module: {e}")
+
+from src.common.utils.helper import get_device
+from src.common.session import Session
+from src.types.llm.transformers import TransformersSpeechLMArgs
+from .base import TransformersBaseLLM
+from .streamer import TokenStreamer
+
+
+class TransformersGenerator(TransformersBaseLLM):
+    """
+    token_ids -> llm generate stream -> token_ids
+    use transformers llm engine to generate token_ids
+    """
+
+    TAG = "llm_transformers_generator"
+
+    def __init__(self, **args):
+        self.args = TransformersSpeechLMArgs(**args)
+        self.args.lm_device = self.args.lm_device or get_device()
+        logging.info("TransformersLMArgs: %s", self.args)
+        self._model = AutoModelForCausalLM.from_pretrained(self.args.lm_model_name_or_path)
+        self._model.eval().to(self.args.lm_device)
+
+        self.warmup()
+
+    def warmup(self):
+        if self.args.warmup_steps <= 0 or not self.args.warnup_prompt:
+            logging.info("no warmup!")
+            return
+
+        self.tokenizer = AutoTokenizer.from_pretrained(self.args.lm_model_name_or_path)
+        model_inputs = self.tokenizer([self.args.warnup_prompt], return_tensors="pt").to(
+            self.args.lm_device
+        )
+
+        streamer = TokenStreamer(skip_prompt=True)
+        warmup_gen_kwargs = dict(
+            **model_inputs,
+            streamer=streamer,
+            min_new_tokens=self.args.lm_gen_min_new_tokens,
+            max_new_tokens=self.args.lm_gen_max_new_tokens,
+            top_k=self.args.lm_gen_top_k,
+            top_p=self.args.lm_gen_top_p,
+            do_sample=self.args.lm_gen_do_sample,
+            temperature=self.args.lm_gen_temperature,
+            repetition_penalty=self.args.lm_gen_repetition_penalty,
+        )
+
+        self._warmup(
+            target=self._model.generate,
+            kwargs=warmup_gen_kwargs,
+            streamer=streamer,
+        )
+
+    # @torch.no_grad()
+    @torch.inference_mode()
+    def generate(self, session: Session, **kwargs):
+        """
+        token_ids -> llm generate stream -> token_ids
+        """
+        assert session.ctx.state["token_ids"] is not None
+        assert isinstance(session.ctx.state["token_ids"], list)
+        token_ids = session.ctx.state["token_ids"]
+        input_ids = torch.IntTensor([token_ids]).to(self.device)
+
+        # https://huggingface.co/docs/transformers/v4.50.0/en/main_classes/text_generation
+        streamer = TokenStreamer(skip_prompt=True)
+        kwargs["max_length"] = kwargs.get("max_length", self.args.lm_gen_max_length)
+        kwargs["max_new_tokens"] = kwargs.get("max_new_tokens", self.args.lm_gen_max_new_tokens)
+        kwargs["top_k"] = kwargs.get("top_k", self.args.lm_gen_top_k)
+        kwargs["top_p"] = kwargs.get("top_p", self.args.lm_gen_top_p)
+        kwargs["do_sample"] = (
+            True if kwargs.get("temperature", self.args.lm_gen_temperature) > 0.0 else False
+        )
+        kwargs["temperature"] = kwargs.get("temperature", self.args.lm_gen_temperature)
+        kwargs["repetition_penalty"] = kwargs.get(
+            "repetition_penalty", self.args.lm_gen_repetition_penalty
+        )
+        kwargs["min_new_tokens"] = kwargs.get("min_new_tokens", self.args.lm_gen_min_new_tokens)
+        generation_kwargs = dict(
+            input_ids=input_ids,
+            streamer=streamer,
+            **kwargs,
+        )
+        logging.debug("generation_kwargs", generation_kwargs)
+        thread = Thread(target=self._model.generate, kwargs=generation_kwargs)
+        thread.start()
+
+        for token_id in streamer:
+            # print(token_id, end=",", flush=True)
+            yield token_id

--- a/src/core/llm/transformers/manual.py
+++ b/src/core/llm/transformers/manual.py
@@ -35,7 +35,7 @@ class TransformersManualLLM(TransformersBaseLLM):
 
         self._warmup(target=self._model.generate, kwargs=warmup_gen_kwargs, streamer=streamer)
 
-    def generate(self, session: Session):
+    def generate(self, session: Session, **kwargs):
         prompt = session.ctx.state["prompt"]
         if isinstance(prompt, tuple):
             prompt, language_code = prompt

--- a/src/core/llm/transformers/manual_speech_orpheus.py
+++ b/src/core/llm/transformers/manual_speech_orpheus.py
@@ -6,7 +6,7 @@ try:
     from transformers import AutoTokenizer, AutoModelForCausalLM
 except ModuleNotFoundError as e:
     logging.error(f"Exception: {e}")
-    logging.error("you need to `pip install achatbot[llm_transformers_manual_speech_llama]`,")
+    logging.error("you need to `pip install achatbot[llm_transformers_manual_speech_orpheus]`,")
     raise Exception(f"Missing module: {e}")
 
 from src.common.utils.helper import get_device
@@ -16,12 +16,12 @@ from .base import TransformersBaseLLM
 from .streamer import TokenStreamer
 
 
-class TransformersManualSpeechLlama(TransformersBaseLLM):
+class TransformersManualSpeechOrpheus(TransformersBaseLLM):
     """
     TTS: text -> llama3 -> vq code tokens
     """
 
-    TAG = "llm_transformers_manual_speech_llama"
+    TAG = "llm_transformers_manual_speech_orpheus"
     DEFAULT_SYS_PROMPT = ""
 
     def __init__(self, **args):
@@ -73,7 +73,7 @@ class TransformersManualSpeechLlama(TransformersBaseLLM):
     @torch.inference_mode()
     def generate(self, session: Session, **kwargs):
         """
-        TTS: text -> llama2 -> vq code tokens
+        TTS: text -> llama3 -> vq code tokens
         """
         prompt = session.ctx.state["prompt"]  # tts text
         if "vq_code_prompt" in session.ctx.state and isinstance(

--- a/src/core/llm/vllm/generator.py
+++ b/src/core/llm/vllm/generator.py
@@ -44,23 +44,29 @@ class VllmGenerator(BaseLLM, ILlmGenerator):
         # https://docs.vllm.ai/en/stable/api/inference_params.html#vllm.SamplingParams
         sampling_params = SamplingParams(
             n=1,
-            seed=kwargs.get("seed", self.gen_args.lm_gen_seed),
-            max_tokens=kwargs.get(
-                "max_new_tokens",
-                self.gen_args.lm_gen_max_new_tokens,
-            ),
-            temperature=kwargs.get("temperature", self.gen_args.lm_gen_temperature),
-            top_p=kwargs.get("top_p", self.gen_args.lm_gen_top_p),
-            top_k=kwargs.get("top_k", self.gen_args.lm_gen_top_k),
-            min_p=kwargs.get("min_p", self.gen_args.lm_gen_min_p),
+            seed=kwargs.get("seed") if kwargs.get("seed") else self.gen_args.lm_gen_seed,
+            max_tokens=kwargs.get("max_new_tokens")
+            if kwargs.get("max_new_tokens")
+            else self.gen_args.lm_gen_max_new_tokens,
+            temperature=kwargs.get("temperature")
+            if kwargs.get("temperature")
+            else self.gen_args.lm_gen_temperature,
+            top_p=kwargs.get("top_p") if kwargs.get("top_p") else self.gen_args.lm_gen_top_p,
+            top_k=kwargs.get("top_k") if kwargs.get("top_k") else self.gen_args.lm_gen_top_k,
+            min_p=kwargs.get("min_p") if kwargs.get("min_p") else self.gen_args.lm_gen_min_p,
             # Penalizers,
-            repetition_penalty=kwargs.get(
-                "repetition_penalty",
-                self.gen_args.lm_gen_repetition_penalty,
-            ),
-            min_tokens=kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new_tokens),
-            stop_token_ids=kwargs.get("stop_ids", self.gen_args.lm_gen_stop_ids),
-            stop=kwargs.get("stop_tokens", self.gen_args.lm_gen_stops),
+            repetition_penalty=kwargs.get("repetition_penalty")
+            if kwargs.get("repetition_penalty")
+            else self.gen_args.lm_gen_repetition_penalty,
+            min_tokens=kwargs.get("min_new_tokens")
+            if kwargs.get("min_new_tokens")
+            else self.gen_args.lm_gen_min_new_tokens,
+            stop_token_ids=kwargs.get("stop_ids")
+            if kwargs.get("stop_ids")
+            else self.gen_args.lm_gen_stop_ids,
+            stop=kwargs.get("stop_tokens")
+            if kwargs.get("stop_tokens")
+            else self.gen_args.lm_gen_stops,
         )
         # https://docs.vllm.ai/en/stable/api/offline_inference/llm.html#vllm.LLM.generate
         iterator = self.engine.generate(

--- a/src/core/llm/vllm/generator.py
+++ b/src/core/llm/vllm/generator.py
@@ -12,9 +12,10 @@ except ModuleNotFoundError as e:
     raise Exception(f"Missing module: {e}")
 
 from src.common.session import Session
+from src.core.llm.base import BaseLLM  
 
 
-class VllmGenerator:
+class VllmGenerator(BaseLLM):
     """
     token_ids -> llm generate stream -> token_ids
     use vllm llm engine frontend asyncio api to generate token_ids

--- a/src/core/llm/vllm/generator.py
+++ b/src/core/llm/vllm/generator.py
@@ -57,6 +57,8 @@ class VllmGenerator:
                 self.gen_args.lm_gen_repetition_penalty,
             ),
             min_tokens=kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new),
+            stop_token_ids=kwargs.get("stop_ids", self.gen_args.lm_gen_stop_ids),
+            stop=kwargs.get("stop_tokens", self.gen_args.lm_gen_stops),
         )
         # https://docs.vllm.ai/en/stable/api/offline_inference/llm.html#vllm.LLM.generate
         iterator = self.engine.generate(
@@ -72,6 +74,8 @@ class VllmGenerator:
 
 """
 MODEL=./models/Qwen/Qwen2.5-0.5B python -m src.core.llm.vllm.generator 
+MODEL=./models/Qwen/Qwen2.5-0.5B-Instruct python -m src.core.llm.vllm.generator 
+
 """
 if __name__ == "__main__":
     from src.common.types import SessionCtx

--- a/src/core/llm/vllm/generator.py
+++ b/src/core/llm/vllm/generator.py
@@ -11,11 +11,12 @@ except ModuleNotFoundError as e:
     logging.error("you need to `pip install achatbot[vllm]`")
     raise Exception(f"Missing module: {e}")
 
+from src.common.interface import ILlmGenerator
 from src.common.session import Session
-from src.core.llm.base import BaseLLM  
+from src.core.llm.base import BaseLLM
 
 
-class VllmGenerator(BaseLLM):
+class VllmGenerator(BaseLLM, ILlmGenerator):
     """
     token_ids -> llm generate stream -> token_ids
     use vllm llm engine frontend asyncio api to generate token_ids

--- a/src/core/llm/vllm/generator.py
+++ b/src/core/llm/vllm/generator.py
@@ -1,0 +1,93 @@
+import logging
+import uuid
+
+
+try:
+    from src.types.llm.vllm import VllmEngineArgs, AsyncEngineArgs, LMGenerateArgs
+    from vllm import AsyncLLMEngine, SamplingParams
+except ModuleNotFoundError as e:
+    logging.error(f"Exception: {e}")
+    logging.error("you need to `pip install achatbot[vllm]`")
+    raise Exception(f"Missing module: {e}")
+
+from src.common.session import Session
+from src.common.device_cuda import CUDAInfo
+
+
+class VllmGenerator:
+    """
+    token_ids -> llm generate stream -> token_ids
+    use vllm llm engine frontend asyncio api to generate token_ids
+    https://docs.vllm.ai/en/stable/models/generative_models.html
+    todo: maybe use backend method to generate token_ids
+    """
+
+    TAG = "llm_vllm_generator"
+
+    def __init__(self, **kwargs):
+        self.args = VllmEngineArgs(**kwargs)
+        self.gen_args = LMGenerateArgs(**self.args.gen_args)
+        # https://docs.vllm.ai/en/stable/serving/engine_args.html#engine-args
+        self.serv_args = AsyncEngineArgs(**self.args.serv_args)
+        self.engine = AsyncLLMEngine.from_engine_args(self.serv_args)
+
+    async def generate(self, session: Session, **kwargs):
+        """
+        Generate new tokens using the LLM model.
+        """
+        assert session.ctx.state["token_ids"] is not None
+        assert isinstance(session.ctx.state["token_ids"], list)
+        token_ids = session.ctx.state["token_ids"]
+
+        # https://docs.vllm.ai/en/stable/api/inference_params.html#vllm.SamplingParams
+        sampling_params = SamplingParams(
+            n=1,
+            seed=kwargs.get("seed", self.gen_args.lm_gen_seed),
+            max_tokens=kwargs.get(
+                "max_new_tokens",
+                self.gen_args.lm_gen_max_new_tokens,
+            ),
+            temperature=kwargs.get("temperature", self.gen_args.lm_gen_temperature),
+            top_p=kwargs.get("top_p", self.gen_args.lm_gen_top_p),
+            top_k=kwargs.get("top_k", self.gen_args.lm_gen_top_k),
+            min_p=kwargs.get("min_p", self.gen_args.lm_gen_min_p),
+            # Penalizers,
+            repetition_penalty=kwargs.get(
+                "repetition_penalty",
+                self.gen_args.lm_gen_repetition_penalty,
+            ),
+            min_tokens=kwargs.get("min_new_tokens", self.gen_args.lm_gen_min_new),
+        )
+        # https://docs.vllm.ai/en/stable/api/offline_inference/llm.html#vllm.LLM.generate
+        iterator = self.engine.generate(
+            prompt_token_ids=token_ids,
+            sampling_params=sampling_params,
+            request_id=session.ctx.client_id,
+        )
+        async for part in iterator:
+            if part.outputs:
+                token_id = part.outputs[0].token_ids[-1]
+                yield token_id
+
+
+"""
+MODEL=./models/Qwen/Qwen2.5-0.5B python -m src.core.llm.vllm.generator 
+"""
+if __name__ == "__main__":
+    from src.common.types import SessionCtx
+    import uuid
+    import os
+    import asyncio
+
+    generator = VllmGenerator(
+        **VllmEngineArgs(
+            serv_args=AsyncEngineArgs(model=os.getenv("MODEL", "Qwen/Qwen2.5-0.5B")).__dict__
+        ).__dict__,
+    )
+
+    async def run():
+        session = Session(**SessionCtx(str(uuid.uuid4().hex)).__dict__)
+        async for token_id in generator.generate(session, max_new_tokens=3):
+            print(token_id)
+
+    asyncio.run(run())

--- a/src/modules/speech/tts/orpheus_tts.py
+++ b/src/modules/speech/tts/orpheus_tts.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 import numpy as np
 import torch
 
-from src.core.llm.transformers.manual_speech_llama import TransformersManualSpeechLlama
+from src.core.llm.transformers.manual_speech_orpheus import TransformersManualSpeechOrpheus
 from src.common.random import set_all_random_seed
 from src.common.interface import ITts
 from src.common.session import Session
@@ -44,7 +44,7 @@ class OrpheusTTS(BaseTTS, ITts):
         self.args = OrpheusTTSArgs(**kwargs)
         self.args.lm_args = TransformersSpeechLMArgs(**self.args.lm_args)
         self.args.codec_args = CodecArgs(**self.args.codec_args)
-        self.lm_model = TransformersManualSpeechLlama(**self.args.lm_args.__dict__)
+        self.lm_model = TransformersManualSpeechOrpheus(**self.args.lm_args.__dict__)
         self.codec_model = SNACCodec(**self.args.codec_args.__dict__)
 
         self.voice_name = self.args.voice_name

--- a/src/types/llm/sampling.py
+++ b/src/types/llm/sampling.py
@@ -64,3 +64,15 @@ class LMGenerateArgs:
             "help": "Controls the token repetition pealty.  no repetition Default is 1.0, >1.0: low repetition, <1.0: high repetition"
         },
     )
+    lm_gen_stops: list[str] = field(
+        default_factory=list,
+        metadata={
+            "help": "A list of strings that will stop the generation. Default is []. If the stop word is a substring of the generated text, the generation will stop."
+        },
+    )
+    lm_gen_stop_ids: list[int] = field(
+        default_factory=list,
+        metadata={
+            "help": "A list of token ids that will stop the generation. Default is []. If the stop id is a substring token id of the generated text, the generation will stop."
+        },
+    )

--- a/src/types/llm/sampling.py
+++ b/src/types/llm/sampling.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class LMGenerateArgs:
+    """lm generation sampling arguments"""
+
+    lm_gen_seed: int = field(
+        default=42,
+        metadata={"help": "The seed to use for the language model. Default is 42."},
+    )
+    lm_max_length: int = field(
+        default=2048,
+        metadata={
+            "help": "Corresponds to the length of the input prompt + max_new_tokens. Its effect is overridden by max_new_tokens, if also set. Default is 2048."
+        },
+    )
+    lm_gen_max_new_tokens: int = field(
+        default=1024,
+        metadata={
+            "help": "Maximum number of new tokens to generate in a single completion. Default is 1024."
+        },
+    )
+    lm_gen_min_new_tokens: int = field(
+        default=0,
+        metadata={
+            "help": "Minimum number of new tokens to generate in a single completion. Default is 0."
+        },
+    )
+    lm_gen_do_sample: bool = field(
+        default=True,
+        metadata={
+            "help": "Whether to use sampling; set this to False for deterministic outputs. Default is False."
+        },
+    )
+    lm_gen_temperature: float = field(
+        default=0.1,
+        metadata={
+            "help": "Controls the randomness of the output. Set to 0.0 for deterministic (repeatable) outputs. Default is 0.1."
+        },
+    )
+    lm_gen_top_k: int = field(
+        default=20,
+        metadata={
+            "help": "Changing the top - k parameter sets the size of the shortlist the model samples from as it outputs each token. Setting top - k to 1 gives us greedy decoding. Default is 1"
+        },
+    )
+    lm_gen_top_p: float = field(
+        default=0.8,
+        metadata={
+            "help": "Top-p is usually set to a high value (like 0.75) with the purpose of limiting the long tail of low-probability tokens that may be sampled. We can use both top-k and top-p together. If both k and p are enabled, p acts after k. Default is 0.8."
+        },
+    )
+    # https://github.com/huggingface/transformers/issues/27670
+    lm_gen_min_p: float = field(
+        default=0.0,
+        metadata={
+            "help": "samples from tokens with probability larger than min_p * highest_token_probability. Default is 0.0."
+        },
+    )
+    lm_gen_repetition_penalty: float = field(
+        default=1.0,
+        metadata={
+            "help": "Controls the token repetition pealty.  no repetition Default is 1.0, >1.0: low repetition, <1.0: high repetition"
+        },
+    )

--- a/src/types/llm/sglang.py
+++ b/src/types/llm/sglang.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass, field
+
+from sglang.srt.server_args import ServerArgs
+from .sampling import LMGenerateArgs
+
+
+@dataclass
+class SGLangEngineArgs:
+    """
+    SGLang language model engine args
+    """
+
+    serv_args: dict = field(default_factory=lambda: ServerArgs().__dict__)
+    gen_args: dict = field(default_factory=lambda: LMGenerateArgs().__dict__)

--- a/src/types/llm/tensorrt_llm.py
+++ b/src/types/llm/tensorrt_llm.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass, field
+
+
+from .sampling import LMGenerateArgs
+
+
+@dataclass
+class TensorRTLLMEngineArgs:
+    """
+    TensorRT-llm language model engine args
+    """
+
+    serv_args: dict = {}
+    gen_args: dict = field(default_factory=lambda: LMGenerateArgs().__dict__)

--- a/src/types/llm/tensorrt_llm.py
+++ b/src/types/llm/tensorrt_llm.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 
+from tensorrt_llm.llmapi.llm_args import LlmArgs
+
 
 from .sampling import LMGenerateArgs
 
@@ -10,5 +12,5 @@ class TensorRTLLMEngineArgs:
     TensorRT-llm language model engine args
     """
 
-    serv_args: dict = {}
+    serv_args: dict = field(default_factory=lambda: LlmArgs().__dict__)
     gen_args: dict = field(default_factory=lambda: LMGenerateArgs().__dict__)

--- a/src/types/llm/tensorrt_llm.py
+++ b/src/types/llm/tensorrt_llm.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from tensorrt_llm.llmapi.llm_args import LlmArgs
+from tensorrt_llm.llmapi.llm_utils import LlmArgs
 
 
 from .sampling import LMGenerateArgs

--- a/src/types/llm/transformers.py
+++ b/src/types/llm/transformers.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass, field
 
+from .sampling import LMGenerateArgs
+
 
 @dataclass
-class TransformersLMArgs:
+class TransformersLMArgs(LMGenerateArgs):
     r"""
     HF transformers language model args (tiny,small,large,huge)
     https://huggingface.co/docs/transformers/main/en/main_classes/text_generation#transformers.GenerationConfig
@@ -59,58 +61,6 @@ class TransformersLMArgs:
         default="You are a helpful and friendly AI assistant. You are polite, respectful, and aim to provide concise responses of less than 20 words.",
         metadata={
             "help": "The initial chat prompt to establish context for the language model. Default is 'You are a helpful AI assistant.'"
-        },
-    )
-    lm_gen_seed: int = field(
-        default=42,
-        metadata={"help": "The seed to use for the language model. Default is 42."},
-    )
-    lm_max_length: int = field(
-        default=2048,
-        metadata={
-            "help": "Corresponds to the length of the input prompt + max_new_tokens. Its effect is overridden by max_new_tokens, if also set. Default is 2048."
-        },
-    )
-    lm_gen_max_new_tokens: int = field(
-        default=1024,
-        metadata={
-            "help": "Maximum number of new tokens to generate in a single completion. Default is 1024."
-        },
-    )
-    lm_gen_min_new_tokens: int = field(
-        default=0,
-        metadata={
-            "help": "Minimum number of new tokens to generate in a single completion. Default is 0."
-        },
-    )
-    lm_gen_do_sample: bool = field(
-        default=True,
-        metadata={
-            "help": "Whether to use sampling; set this to False for deterministic outputs. Default is False."
-        },
-    )
-    lm_gen_temperature: float = field(
-        default=0.1,
-        metadata={
-            "help": "Controls the randomness of the output. Set to 0.0 for deterministic (repeatable) outputs. Default is 0.1."
-        },
-    )
-    lm_gen_top_k: int = field(
-        default=1,
-        metadata={
-            "help": "Changing the top - k parameter sets the size of the shortlist the model samples from as it outputs each token. Setting top - k to 1 gives us greedy decoding. Default is 1"
-        },
-    )
-    lm_gen_top_p: float = field(
-        default=0.8,
-        metadata={
-            "help": "Top-p is usually set to a high value (like 0.75) with the purpose of limiting the long tail of low-probability tokens that may be sampled. We can use both top-k and top-p together. If both k and p are enabled, p acts after k. Default is 0.8."
-        },
-    )
-    lm_gen_repetition_penalty: float = field(
-        default=1.0,
-        metadata={
-            "help": "Controls the token repetition pealty.  no repetition Default is 1.0, >1.0: low repetition, <1.0: high repetition"
         },
     )
     lm_tokenizer_decode_batch_size: int = field(

--- a/src/types/llm/vllm.py
+++ b/src/types/llm/vllm.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+
+from vllm import AsyncEngineArgs
+
+from .sampling import LMGenerateArgs
+
+
+@dataclass
+class VllmEngineArgs:
+    """
+    vllm language model engine args
+    """
+
+    serv_args: dict = field(default_factory=lambda: AsyncEngineArgs().__dict__)
+    gen_args: dict = field(default_factory=lambda: LMGenerateArgs().__dict__)

--- a/test/core/llm/test_generator.py
+++ b/test/core/llm/test_generator.py
@@ -6,6 +6,7 @@ import unittest
 import uuid
 from dotenv import load_dotenv
 
+from src.common.interface import ILlmGenerator
 from src.core.llm.base import BaseLLM
 from src.common.logger import Logger
 from src.common.session import Session
@@ -38,7 +39,7 @@ LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
 """
 
 
-class TestGenerator(unittest.TestCase):
+class TestGenerator(unittest.IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):
         cls.llm_tag = os.getenv("LLM_TAG", "llm_transformers_generator")
@@ -55,7 +56,8 @@ class TestGenerator(unittest.TestCase):
 
         engine = LLMEnvInit.initLLMEngine(self.llm_tag)
         self.assertIsInstance(engine, BaseLLM)
-        self.engine: BaseLLM = engine
+        self.assertIsInstance(engine, ILlmGenerator)
+        self.engine: ILlmGenerator = engine
         logging.debug(self.engine.args)
 
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_path)
@@ -70,7 +72,7 @@ class TestGenerator(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_generate(self):
+    async def test_generate(self):
         prompt_cases = [
             {"prompt": self.prompt, "kwargs": {"max_new_tokens": 20, "stop_ids": []}},
             {"prompt": self.prompt, "kwargs": {"max_new_tokens": 20, "stop_ids": [13]}},
@@ -87,7 +89,7 @@ class TestGenerator(unittest.TestCase):
                 generated_token_ids = []
                 times = []
                 start_time = perf_counter()
-                for item in iter:
+                async for item in iter:
                     # print(item)
                     generated_token_ids.append(item)
                     times.append(perf_counter() - start_time)

--- a/test/core/llm/test_generator.py
+++ b/test/core/llm/test_generator.py
@@ -1,0 +1,105 @@
+import os
+import logging
+
+from time import perf_counter
+import unittest
+import uuid
+from dotenv import load_dotenv
+
+from src.core.llm.base import BaseLLM
+from src.common.logger import Logger
+from src.common.session import Session
+from src.common.types import MODELS_DIR, SessionCtx
+from src.core.llm import LLMEnvInit
+
+load_dotenv(override=True)
+
+r"""
+LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
+    LLM_TAG=llm_transformers_generator \
+    python -m unittest test.core.llm.test_generator.TestGenerator.test_generate
+
+LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
+    LLM_MODEL_PATH=./models/qwen2.5-0.5b-instruct-q8_0.gguf \
+    LLM_TAG=llm_llamacpp_generator \
+    python -m unittest test.core.llm.test_generator.TestGenerator.test_generate
+
+LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
+    LLM_TAG=llm_vllm_generator \
+    python -m unittest test.core.llm.test_generator.TestGenerator.test_generate
+
+LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
+    LLM_TAG=llm_sglang_generator \
+    python -m unittest test.core.llm.test_generator.TestGenerator.test_generate
+
+LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
+    LLM_TAG=llm_trtllm_generator \
+    python -m unittest test.core.llm.test_generator.TestGenerator.test_generate
+"""
+
+
+class TestGenerator(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.llm_tag = os.getenv("LLM_TAG", "llm_transformers_generator")
+        cls.prompt = os.getenv("LLM_PROMPT", "what's your name?")
+        cls.model_path = os.getenv("LLM_MODEL_NAME_OR_PATH", "./models/Qwen/Qwen2.5-0.5B")
+        Logger.init(os.getenv("LOG_LEVEL", "debug").upper(), is_file=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        from transformers import AutoTokenizer, GenerationConfig
+
+        engine = LLMEnvInit.initLLMEngine(self.llm_tag)
+        self.assertIsInstance(engine, BaseLLM)
+        self.engine: BaseLLM = engine
+        logging.debug(self.engine.args)
+
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_path)
+        self.generation_config = {}
+        if os.path.exists(os.path.join(self.model_path, "generation_config.json")):
+            self.generation_config = GenerationConfig.from_pretrained(
+                self.model_path, "generation_config.json"
+            ).to_dict()
+
+        self.session = Session(**SessionCtx(f"{self.llm_tag}_" + str(uuid.uuid4().hex)).__dict__)
+
+    def tearDown(self):
+        pass
+
+    def test_generate(self):
+        prompt_cases = [
+            {"prompt": self.prompt, "kwargs": {"max_new_tokens": 20, "stop_ids": []}},
+            {"prompt": self.prompt, "kwargs": {"max_new_tokens": 20, "stop_ids": [13]}},
+        ]
+
+        for case in prompt_cases:
+            with self.subTest(case=case):
+                tokens = self.tokenizer(case["prompt"])
+                self.session.ctx.state["token_ids"] = tokens["input_ids"]
+                gen_kwargs = {**self.generation_config, **case["kwargs"], **tokens}
+                logging.debug(gen_kwargs)
+                iter = self.engine.generate(self.session, **gen_kwargs)
+
+                generated_token_ids = []
+                times = []
+                start_time = perf_counter()
+                for item in iter:
+                    # print(item)
+                    generated_token_ids.append(item)
+                    times.append(perf_counter() - start_time)
+                    start_time = perf_counter()
+                logging.debug(f"chat_completion TTFT time: {times[0]} s")
+                self.assertGreater(len(generated_token_ids), 0)
+                if "max_new_tokens" in case["kwargs"]:
+                    max_new_tokens = case["kwargs"]["max_new_tokens"]
+                    self.assertLessEqual(len(generated_token_ids), max_new_tokens)
+                    if len(generated_token_ids) < max_new_tokens:
+                        if "stop_ids" in case["kwargs"]:
+                            for stop_id in case["kwargs"]["stop_ids"]:
+                                self.assertIn(stop_id, generated_token_ids)
+                generated_text = self.tokenizer.decode(generated_token_ids)
+                logging.debug(f"generated text: {generated_text}")

--- a/test/core/llm/test_generator.py
+++ b/test/core/llm/test_generator.py
@@ -51,6 +51,9 @@ class TestGenerator(unittest.IsolatedAsyncioTestCase):
     def tearDownClass(cls):
         pass
 
+    async def asyncSetUp(self):
+        pass
+
     def setUp(self):
         from transformers import AutoTokenizer, GenerationConfig
 
@@ -70,6 +73,9 @@ class TestGenerator(unittest.IsolatedAsyncioTestCase):
         self.session = Session(**SessionCtx(f"{self.llm_tag}_" + str(uuid.uuid4().hex)).__dict__)
 
     def tearDown(self):
+        pass
+
+    async def asyncTearDown(self):
         pass
 
     async def test_generate(self):


### PR DESCRIPTION
feat: 
- add transformers, llamacpp, vllm, sglang, tensorrt-llm engine generator
- add unit test
```shell
# flashinfer needs to define TORCH_CUDA_ARCH_LIST
export TORCH_CUDA_ARCH_LIST="7.5 8.0 8.6 8.7 8.9 9.0"

LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
    LLM_TAG=llm_transformers_generator \
    python -m unittest test.core.llm.test_generator.TestGenerator.test_generate

LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
    LLM_MODEL_PATH=./models/qwen2.5-0.5b-instruct-q8_0.gguf \
    LLM_TAG=llm_llamacpp_generator \
    python -m unittest test.core.llm.test_generator.TestGenerator.test_generate

LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
    LLM_TAG=llm_vllm_generator \
    python -m unittest test.core.llm.test_generator.TestGenerator.test_generate

LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
    LLM_TAG=llm_sglang_generator \
    python -m unittest test.core.llm.test_generator.TestGenerator.test_generate

LLM_MODEL_NAME_OR_PATH=./models/Qwen/Qwen2.5-0.5B-Instruct \
    LLM_TAG=llm_trtllm_generator \
    python -m unittest test.core.llm.test_generator.TestGenerator.test_generate
```
- add modal example

vllm
```shell
modal run src/llm/vllm/examples/generate.py::run_sync (no stream)
modal run src/llm/vllm/examples/generate.py::run_async (stream)
modal run src/llm/vllm/examples/generate.py::run_achatbot_generator (stream)
```

sglang
```shell
modal run src/llm/sglang/examples/generate.py::run_sync (stream)
modal run src/llm/sglang/examples/generate.py::run_async (stream)
modal run src/llm/sglang/examples/generate.py::run_achatbot_generator (stream)
```

tensorrt-llm

```shell
# llmapi (LLM load hf model, convert to tensorrt, build tensorrt engine, load tensorrt engine)
modal run src/llm/trtllm/examples/generator.py::run_sync (no stream | batch prompts processing | throughput)
modal run src/llm/trtllm/examples/generator.py::run_async_stream (stream | single prompt async processing | latency)
modal run src/llm/trtllm/examples/generator.py::run_async_batch_stream (stream | batch prompts async processing | latency+throughput) (multiple prompts/request or one prompt/request)

# runner (load tensorrt engine to run generate)

# achatbot
modal run src/llm/trtllm/examples/generator.py::run_achatbot_generator
```

> [!TIP]
> - pt AR模型的generate任务推理接口， token ids -> generate LM (AR) -> token id ，主要的推理优化接口
> - 其中 vllm, sglang, tensorrt-llm 使用的是前端generate接口，使用流式单个输出, 后端使用flashattention, flashinfer
> - 方便对接sft rl模型（包括多模态语言模型MLM）推理
> - mistralrs(todo)