### PR TITLE
feat: add concurrency tts test

### DIFF
--- a/deploy/modal/src/tts/run_generator_tts.py
+++ b/deploy/modal/src/tts/run_generator_tts.py
@@ -172,19 +172,7 @@ trt_model_cache_vol = modal.Volume.from_name("triton_trtllm_cache_models", creat
             "TTS_TEXT": os.getenv(
                 "TTS_TEXT",
                 # "hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。",
-                # "hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。|PyTorch 将值组织成Tensor ， Tensor是具有丰富数据操作操作的通用 n 维数组。|Module 定义从输入值到输出值的转换，其在正向传递期间的行为由其forward成员函数指定。Module 可以包含Tensor作为参数。|例如，线性模块包含权重参数和偏差参数，其正向函数通过将输入与权重相乘并添加偏差来生成输出。|应用程序通过在自定义正向函数中将本机Module （*例如*线性、卷积等）和Function （例如relu、pool 等）拼接在一起来组成自己的Module 。|典型的训练迭代包含使用输入和标签生成损失的前向传递、用于计算参数梯度的后向传递以及使用梯度更新参数的优化器步骤。|更具体地说，在正向传递期间，PyTorch 会构建一个自动求导图来记录执行的操作。|然后，在反向传播中，它使用自动梯度图进行反向传播以生成梯度。最后，优化器应用梯度来更新参数。训练过程重复这三个步骤，直到模型收敛。",
-                "今日是二零二五年三月十九日，国内外热点事件聚焦于国际局势、经济政策及社会民生领域。|"
-                "国际局势中，某国领导人围绕地区冲突停火问题展开对话，双方同意停止攻击对方能源设施并推动谈判，但对全面停火提议的落实仍存分歧。|"
-                "某地区持续军事行动导致数百人伤亡，引发民众抗议，质疑冲突背后的政治动机。另有一方宣称对连续袭击军事目标负责，称此为对前期打击的回应。|"
-                "欧洲某国通过争议性财政草案，计划放宽债务限制以支持国防与环保项目，引发经济政策讨论。|"
-                "国内动态方面，新修订的市场竞争管理条例将于四月二十日施行，重点规范市场秩序。|"
-                "多部门联合推出机动车排放治理新规，加强对高污染车辆的监管。|"
-                "社会层面，某地涉及非法集资的大案持续引发关注，受害人数以万计，涉案金额高达数百亿元，暴露出特定领域投资风险。|"
-                "经济与科技领域，某科技企业公布年度营收突破三千六百五十九亿元，并上调智能汽车交付目标至三十五万台。|"
-                "另一巨头宣布全面推动人工智能转型，要求各部门绩效与人工智能应用深度绑定，计划年内推出多项相关产品。|"
-                "充电基础设施建设加速，公共充电桩总量已接近四百万个，同比增长超六成。 |"
-                "民生政策方面，多地推出新举措：某地限制顺风车单日接单次数以规范运营，另一地启动职工数字技能培训计划，目标三年内覆盖十万女性从业者。|"
-                "整体来看，今日热点呈现国际博弈复杂化、国内经济科技加速转型、民生政策精准化调整的特点。",
+                "hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。|PyTorch 将值组织成Tensor ， Tensor是具有丰富数据操作操作的通用 n 维数组。|Module 定义从输入值到输出值的转换，其在正向传递期间的行为由其forward成员函数指定。Module 可以包含Tensor作为参数。|例如，线性模块包含权重参数和偏差参数，其正向函数通过将输入与权重相乘并添加偏差来生成输出。|应用程序通过在自定义正向函数中将本机Module （*例如*线性、卷积等）和Function （例如relu、pool 等）拼接在一起来组成自己的Module 。|典型的训练迭代包含使用输入和标签生成损失的前向传递、用于计算参数梯度的后向传递以及使用梯度更新参数的优化器步骤。|更具体地说，在正向传递期间，PyTorch 会构建一个自动求导图来记录执行的操作。|然后，在反向传播中，它使用自动梯度图进行反向传播以生成梯度。最后，优化器应用梯度来更新参数。训练过程重复这三个步骤，直到模型收敛。",
             ),
             "CONCURRENCY_CN": os.getenv("CONCURRENCY_CN", "1"),
         }
@@ -239,6 +227,7 @@ async def run_generator():
     )
 
     generator_tag = os.getenv("TTS_LM_GENERATOR_TAG", "")
+    concurrency_cn = int(os.getenv("CONCURRENCY_CN", "1"))
     quant = os.getenv("QUANT", "")
     tts_engine: ITts = TTSEnvInit.initTTSEngine()
 
@@ -248,6 +237,7 @@ async def run_generator():
         + f"llm generator:{generator_tag}\n"
         + f"quant:{quant}\n"
         + f"cpu:{cpu}\ngpu:{gpu_prop}\n"
+        + f"concurrency_cn:{concurrency_cn}\n"
     )
     file_name = f"test_{tts_engine.TAG}_{generator_tag}_{quant}_{device}_{gpu_arch}"
     stream_info = tts_engine.get_stream_info()
@@ -297,7 +287,6 @@ async def run_generator():
         gen_global_token_ids = warmup_res.get("gen_global_token_ids")
 
     texts = os.getenv("TTS_TEXT").split("|")
-    concurrency_cn = int(os.getenv("CONCURRENCY_CN", "1"))
     iter_cn = math.ceil(len(texts) / concurrency_cn)
     for idx in range(iter_cn):
         texts_chunk = texts[idx * concurrency_cn : (idx + 1) * concurrency_cn]
@@ -389,37 +378,37 @@ TTS_TAG=tts_generator_spark IMAGE_GPU=L4 LLM_ATTN_IMPL=flash_attention_2 LLM_DEV
 
 # f16 don't support
 # llamacpp with cpu, quant Q8_0
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q8_0 ACHATBOT_VERSION=0.0.9.post5 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q8_0 ACHATBOT_VERSION=0.0.9.post6 modal run src/tts/run_generator_tts.py
 # llamacpp with cpu, quant Q4_K_M
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q4_K_M ACHATBOT_VERSION=0.0.9.post5 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q4_K_M ACHATBOT_VERSION=0.0.9.post6 modal run src/tts/run_generator_tts.py
 # llamacpp with cpu, quant Q2_K
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q2_K ACHATBOT_VERSION=0.0.9.post5 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q2_K ACHATBOT_VERSION=0.0.9.post6 modal run src/tts/run_generator_tts.py
 # llamacpp with gpu cuda, quant Q8_0 flash attention
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q8_0 ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q8_0 ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
 # llamacpp with gpu cuda, quant Q4_K_M flash attention
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q4_K_M ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q4_K_M ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
 # llamacpp with gpu cuda, quant Q2_K
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q2_K ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=T4 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q2_K ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=T4 modal run src/tts/run_generator_tts.py
 
 # vllm with gpu cuda | bf16 | Using Flash Attention backend | Using FlashInfer for top-p & top-k sampling
-GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
-GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 
 # sglang with gpu cuda | bf16 | Using FlashInfer Attention backend (flashinfer.jit)
-GENERATOR_ENGINE=sglang TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=sglang TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 
 # tensorrt-llm with gpu cuda | bf16
-GENERATOR_ENGINE=trtllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=trtllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 # tensorrt-llm runner with gpu cuda | bf16
-GENERATOR_ENGINE=trtllm_runner TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=trtllm_runner TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 
 Tips: run trtllm_runner generator engine, if use diff gpu arch, need rebuild engine 
 
 # CONCURRENCY_CN=4
-CONCURRENCY_CN=4 GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
-CONCURRENCY_CN=4 GENERATOR_ENGINE=sglang TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
-CONCURRENCY_CN=4 GENERATOR_ENGINE=trtllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
-CONCURRENCY_CN=4 GENERATOR_ENGINE=trtllm_runner TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+CONCURRENCY_CN=4 GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+CONCURRENCY_CN=4 GENERATOR_ENGINE=sglang TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+CONCURRENCY_CN=4 GENERATOR_ENGINE=trtllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+CONCURRENCY_CN=4 GENERATOR_ENGINE=trtllm_runner TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post6 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 """
 
 

--- a/deploy/modal/src/tts/run_generator_tts.py
+++ b/deploy/modal/src/tts/run_generator_tts.py
@@ -90,7 +90,8 @@ if generator == "vllm":
     tts_grpc_image = tts_grpc_image.pip_install(
         f"achatbot[vllm]=={achatbot_version}",
         "flashinfer-python==0.2.0.post2",
-        extra_options="--find-links https://flashinfer.ai/whl/cu124/torch2.5/flashinfer/",
+        "accelerate",
+        extra_options="--find-links https://flashinfer.ai/whl/cu125/torch2.5/flashinfer/",
         extra_index_url="https://flashinfer.ai/whl/cu125/torch2.5/",
     ).env(
         {
@@ -164,10 +165,26 @@ trt_model_cache_vol = modal.Volume.from_name("triton_trtllm_cache_models", creat
             "LOG_LEVEL": os.getenv("LOG_LEVEL", "info"),
             "TORCH_CUDA_ARCH_LIST": "7.5 8.0 8.6 8.7 8.9 9.0",
             "TTS_TAG": os.getenv("TTS_TAG", "tts_generator_spark"),
+            "WARMUP_TEXT": os.getenv(
+                "WARMUP_TEXT",
+                "hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。",
+            ),
             "TTS_TEXT": os.getenv(
                 "TTS_TEXT",
                 # "hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。",
-                "hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。|PyTorch 将值组织成Tensor ， Tensor是具有丰富数据操作操作的通用 n 维数组。|Module 定义从输入值到输出值的转换，其在正向传递期间的行为由其forward成员函数指定。Module 可以包含Tensor作为参数。|例如，线性模块包含权重参数和偏差参数，其正向函数通过将输入与权重相乘并添加偏差来生成输出。|应用程序通过在自定义正向函数中将本机Module （*例如*线性、卷积等）和Function （例如relu、pool 等）拼接在一起来组成自己的Module 。|典型的训练迭代包含使用输入和标签生成损失的前向传递、用于计算参数梯度的后向传递以及使用梯度更新参数的优化器步骤。|更具体地说，在正向传递期间，PyTorch 会构建一个自动求导图来记录执行的操作。|然后，在反向传播中，它使用自动梯度图进行反向传播以生成梯度。最后，优化器应用梯度来更新参数。训练过程重复这三个步骤，直到模型收敛。",
+                # "hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。|PyTorch 将值组织成Tensor ， Tensor是具有丰富数据操作操作的通用 n 维数组。|Module 定义从输入值到输出值的转换，其在正向传递期间的行为由其forward成员函数指定。Module 可以包含Tensor作为参数。|例如，线性模块包含权重参数和偏差参数，其正向函数通过将输入与权重相乘并添加偏差来生成输出。|应用程序通过在自定义正向函数中将本机Module （*例如*线性、卷积等）和Function （例如relu、pool 等）拼接在一起来组成自己的Module 。|典型的训练迭代包含使用输入和标签生成损失的前向传递、用于计算参数梯度的后向传递以及使用梯度更新参数的优化器步骤。|更具体地说，在正向传递期间，PyTorch 会构建一个自动求导图来记录执行的操作。|然后，在反向传播中，它使用自动梯度图进行反向传播以生成梯度。最后，优化器应用梯度来更新参数。训练过程重复这三个步骤，直到模型收敛。",
+                "今日是二零二五年三月十九日，国内外热点事件聚焦于国际局势、经济政策及社会民生领域。|"
+                "国际局势中，某国领导人围绕地区冲突停火问题展开对话，双方同意停止攻击对方能源设施并推动谈判，但对全面停火提议的落实仍存分歧。|"
+                "某地区持续军事行动导致数百人伤亡，引发民众抗议，质疑冲突背后的政治动机。另有一方宣称对连续袭击军事目标负责，称此为对前期打击的回应。|"
+                "欧洲某国通过争议性财政草案，计划放宽债务限制以支持国防与环保项目，引发经济政策讨论。|"
+                "国内动态方面，新修订的市场竞争管理条例将于四月二十日施行，重点规范市场秩序。|"
+                "多部门联合推出机动车排放治理新规，加强对高污染车辆的监管。|"
+                "社会层面，某地涉及非法集资的大案持续引发关注，受害人数以万计，涉案金额高达数百亿元，暴露出特定领域投资风险。|"
+                "经济与科技领域，某科技企业公布年度营收突破三千六百五十九亿元，并上调智能汽车交付目标至三十五万台。|"
+                "另一巨头宣布全面推动人工智能转型，要求各部门绩效与人工智能应用深度绑定，计划年内推出多项相关产品。|"
+                "充电基础设施建设加速，公共充电桩总量已接近四百万个，同比增长超六成。 |"
+                "民生政策方面，多地推出新举措：某地限制顺风车单日接单次数以规范运营，另一地启动职工数字技能培训计划，目标三年内覆盖十万女性从业者。|"
+                "整体来看，今日热点呈现国际博弈复杂化、国内经济科技加速转型、民生政策精准化调整的特点。",
             ),
             "CONCURRENCY_CN": os.getenv("CONCURRENCY_CN", "1"),
         }
@@ -236,19 +253,16 @@ async def run_generator():
     stream_info = tts_engine.get_stream_info()
     print(f"stream_info:{stream_info}")
 
-    texts = os.getenv("TTS_TEXT").split("|")
-    concurrency_cn = int(os.getenv("CONCURRENCY_CN", "1"))
-    iter_cn = math.ceil(len(texts) / concurrency_cn)
-
-    async def generate(text):
+    async def generate(text, session=None, gen_global_token_ids=None):
+        if session is None:
+            session = Session(**SessionCtx(str(uuid.uuid4().hex)).__dict__)
+            session.ctx.state["tts_text"] = text
+            session.ctx.state["temperature"] = 0.95
         res = bytearray()
         times = []
         if text == "":
-            return {"text": text, "waveform": res, "times": times}
-        session = Session(**SessionCtx(str(uuid.uuid4().hex)).__dict__)
-        session.ctx.state["tts_text"] = text
-        session.ctx.state["temperature"] = 0.95
-        print(session.ctx)
+            return {"text": text, "waveform": res, "times": times, "gen_global_token_ids": []}
+        session.ctx.state["gen_global_token_ids"] = gen_global_token_ids
         iter = tts_engine.synthesize(session)
         start_time = perf_counter()
         i = 0
@@ -258,14 +272,36 @@ async def run_generator():
             print(i, len(chunk))
             i += 1
             start_time = perf_counter()
+        if len(res) == 0:
+            print("no waveform data")
+            return {"text": text, "waveform": res, "times": times, "gen_global_token_ids": []}
         print(
-            f"generate first chunk time: {times[0]} s, {len(res)} waveform cost time: {sum(times)} s, avg cost time: {sum(times)/len(res)}"
+            f"generate first chunk time: {times[0]} s, {len(res)} waveform cost time: {sum(times)} s"
         )
-        return {"text": text, "waveform": res, "times": times}
+        if "gen_global_token_ids" in session.ctx.state:
+            return {
+                "text": text,
+                "waveform": res,
+                "times": times,
+                "gen_global_token_ids": session.ctx.state["gen_global_token_ids"],
+            }
+        return {"text": text, "waveform": res, "times": times, "gen_global_token_ids": []}
 
+    session = Session(**SessionCtx(str(uuid.uuid4().hex)).__dict__)
+    warmup_texts = os.getenv("WARMUP_TEXT").split("|")
+    gen_global_token_ids = None
+    for text in warmup_texts:
+        session.ctx.state["tts_text"] = text
+        session.ctx.state["temperature"] = 0.95
+        warmup_res = await generate(text, session, gen_global_token_ids=gen_global_token_ids)
+        gen_global_token_ids = warmup_res.get("gen_global_token_ids")
+
+    texts = os.getenv("TTS_TEXT").split("|")
+    concurrency_cn = int(os.getenv("CONCURRENCY_CN", "1"))
+    iter_cn = math.ceil(len(texts) / concurrency_cn)
     for idx in range(iter_cn):
         texts_chunk = texts[idx * concurrency_cn : (idx + 1) * concurrency_cn]
-        tasks = [generate(text) for text in texts_chunk]
+        tasks = [generate(text, gen_global_token_ids=gen_global_token_ids) for text in texts_chunk]
         start_time = perf_counter()
         gather_res = await asyncio.gather(*tasks)
         tts_cost_time = perf_counter() - start_time
@@ -304,6 +340,7 @@ async def run_generator():
             )
 
             print(torch.cuda.memory_summary(device=device, abbreviated=True))
+            subprocess.run("nvidia-smi", shell=True)
 
     file_path = os.path.join(ASSETS_DIR, f"{file_name}.log")
     with open(file_path, "w") as f:
@@ -352,31 +389,34 @@ TTS_TAG=tts_generator_spark IMAGE_GPU=L4 LLM_ATTN_IMPL=flash_attention_2 LLM_DEV
 
 # f16 don't support
 # llamacpp with cpu, quant Q8_0
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q8_0 ACHATBOT_VERSION=0.0.9.post3 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q8_0 ACHATBOT_VERSION=0.0.9.post5 modal run src/tts/run_generator_tts.py
 # llamacpp with cpu, quant Q4_K_M
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q4_K_M ACHATBOT_VERSION=0.0.9.post3 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q4_K_M ACHATBOT_VERSION=0.0.9.post5 modal run src/tts/run_generator_tts.py
 # llamacpp with cpu, quant Q2_K
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q2_K ACHATBOT_VERSION=0.0.9.post3 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q2_K ACHATBOT_VERSION=0.0.9.post5 modal run src/tts/run_generator_tts.py
 # llamacpp with gpu cuda, quant Q8_0 flash attention
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q8_0 ACHATBOT_VERSION=0.0.9.post3 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q8_0 ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
 # llamacpp with gpu cuda, quant Q4_K_M flash attention
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q4_K_M ACHATBOT_VERSION=0.0.9.post3 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q4_K_M ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
 # llamacpp with gpu cuda, quant Q2_K
-GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q2_K ACHATBOT_VERSION=0.0.9.post3 IMAGE_GPU=T4 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=llamacpp TTS_TAG=tts_generator_spark QUANT=Q2_K ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=T4 modal run src/tts/run_generator_tts.py
 
 # vllm with gpu cuda | bf16 | Using Flash Attention backend | Using FlashInfer for top-p & top-k sampling
-GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post3 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
-GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post3 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L4 modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 
 # sglang with gpu cuda | bf16 | Using FlashInfer Attention backend (flashinfer.jit)
-GENERATOR_ENGINE=sglang TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post3 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=sglang TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 
 # tensorrt-llm with gpu cuda | bf16
-GENERATOR_ENGINE=trtllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post3 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=trtllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 # tensorrt-llm runner with gpu cuda | bf16
-GENERATOR_ENGINE=trtllm_runner TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post3 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+GENERATOR_ENGINE=trtllm_runner TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 
 Tips: run trtllm_runner generator engine, if use diff gpu arch, need rebuild engine 
+
+# CONCURRENCY_CN=4
+CONCURRENCY_CN=4 GENERATOR_ENGINE=sglang TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 """
 
 

--- a/deploy/modal/src/tts/run_generator_tts.py
+++ b/deploy/modal/src/tts/run_generator_tts.py
@@ -416,7 +416,10 @@ GENERATOR_ENGINE=trtllm_runner TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.
 Tips: run trtllm_runner generator engine, if use diff gpu arch, need rebuild engine 
 
 # CONCURRENCY_CN=4
+CONCURRENCY_CN=4 GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 CONCURRENCY_CN=4 GENERATOR_ENGINE=sglang TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+CONCURRENCY_CN=4 GENERATOR_ENGINE=trtllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
+CONCURRENCY_CN=4 GENERATOR_ENGINE=trtllm_runner TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
 """
 
 

--- a/deploy/modal/src/tts/run_generator_tts.sh
+++ b/deploy/modal/src/tts/run_generator_tts.sh
@@ -30,7 +30,7 @@ QUANTS=${ALLOWED_QUANTS[*]}
 #----- function -------
 
 usage() {
-  echo "Usage: $0 [-h] [-s STAGE] [-t TTS_TEXT] [-g GENERATOR_ENGINE] [-d IMAGE_GPU] [-a TTS_TAG] [-q QUANTS]"
+  echo "Usage: $0 [-h] [-s STAGE] [-t TTS_TEXT] [-g GENERATOR_ENGINE] [-d IMAGE_GPU] [-a TTS_TAG] [-q QUANTS] [-c CONCURRENCE]"
   echo "  -h                 Show this help message and exit."
   echo "  -s STAGE           Set the stage (default: all)."
   echo "                     Valid options: download, run, run_all, all"
@@ -41,6 +41,7 @@ usage() {
   echo "                     Valid options: T4 A10G A100 L4 L40S H100 https://fullstackdeeplearning.com/cloud-gpus/"
   echo "  -a TTS_TAG         Set the TTS tag (default: tts_generator_spark)."
   echo "  -q QUANTS          Set llamapcpp gguf quants (default: ${ALLOWED_QUANTS[*]})."
+  echo "  -c CONCURRENCE     Set concurrency cn (default: 1)."
   echo "e.g.: "
   echo "bash run_generator_tts.sh -s all"
   echo "bash run_generator_tts.sh -s download "
@@ -53,11 +54,18 @@ usage() {
   echo "bash run_generator_tts.sh -s run -t 'hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。' -g sglang -d L4 -a tts_generator_spark "
   echo "bash run_generator_tts.sh -s run -t 'hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。' -g trtllm -d L4 -a tts_generator_spark "
   echo "bash run_generator_tts.sh -s run -t 'hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。' -g trtllm -d L40s -a tts_generator_spark "
+  echo "bash run_generator_tts.sh -s run -t 'hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。' -g trtllm -d L40s -a tts_generator_spark -c 2 "
+  echo "bash run_generator_tts.sh -s run -g vllm -d L40s -a tts_generator_spark -c 4 "
+  echo "bash run_generator_tts.sh -s run -g sglang -d L40s -a tts_generator_spark -c 4 "
+  echo "bash run_generator_tts.sh -s run -g trtllm -d L40s -a tts_generator_spark -c 4 "
+  echo "bash run_generator_tts.sh -s run -g vllm -d L40s -a tts_generator_spark -c 12 "
+  echo "bash run_generator_tts.sh -s run -g sglang -d L40s -a tts_generator_spark -c 12 "
+  echo "bash run_generator_tts.sh -s run -g trtllm -d L40s -a tts_generator_spark -c 12 "
 }
 
 run() {
     local GENERATOR_ENGINE=$1
-    echo "run $TTS_TAG $GENERATOR_ENGINE $IMAGE_GPU"
+    echo "run $TTS_TAG $GENERATOR_ENGINE $IMAGE_GPU $CONCURRENCY_CN"
     if [ -e "src/tts/run_generator_tts.py" ]; then
       echo "src/tts/run_generator_tts.py exists"
       cd src/tts
@@ -132,7 +140,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/../.." || exit
 
 # 处理命令行参数
-while getopts ":t:g:d:a:s:q:h" opt; do
+while getopts ":t:g:d:a:s:q:c:h" opt; do
   case ${opt} in
     t )
       TTS_TEXT=$OPTARG
@@ -151,6 +159,9 @@ while getopts ":t:g:d:a:s:q:h" opt; do
       ;;
     q )
       QUANTS=$OPTARG
+      ;;
+    c )
+      CONCURRENCE=$OPTARG
       ;;
     h )
       usage
@@ -188,9 +199,10 @@ if [[ ! " ${ALLOWED_GPUS[@]} " =~ " ${IMAGE_GPU} " ]]; then
 fi
 
 export EXTRA_INDEX_URL="https://pypi.org/simple/"
-export ACHATBOT_VERSION="0.0.9.post4"
+export ACHATBOT_VERSION="0.0.9.post6"
 export TTS_TAG=$TTS_TAG
 export TTS_TEXT=$TTS_TEXT
+export CONCURRENCY_CN=$CONCURRENCE
 
 
 case $STAGE in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 name = "achatbot"
 #dynamic = ["version"]
 # todo
-version = "0.0.9.post4"
+version = "0.0.9.post5"
 authors = [{ name = "weedge", email = "weege007@gmail.com" }]
 maintainers = [{ name = "weedge", email = "weege007@gmail.com" }]
 description = "An open source chat bot for voice (and multimodal) assistants"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 name = "achatbot"
 #dynamic = ["version"]
 # todo
-version = "0.0.9.post5"
+version = "0.0.9.7.2"
 authors = [{ name = "weedge", email = "weege007@gmail.com" }]
 maintainers = [{ name = "weedge", email = "weege007@gmail.com" }]
 description = "An open source chat bot for voice (and multimodal) assistants"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 name = "achatbot"
 #dynamic = ["version"]
 # todo
-version = "0.0.9.7.2"
+version = "0.0.9.post6"
 authors = [{ name = "weedge", email = "weege007@gmail.com" }]
 maintainers = [{ name = "weedge", email = "weege007@gmail.com" }]
 description = "An open source chat bot for voice (and multimodal) assistants"

--- a/src/core/llm/__init__.py
+++ b/src/core/llm/__init__.py
@@ -171,6 +171,7 @@ class LLMEnvInit:
             ),
             lm_attn_impl=os.getenv("LLM_ATTN_IMPL", None),
             lm_device=os.getenv("LLM_DEVICE", None),
+            lm_device_map=os.getenv("LLM_DEVICE_MAP", None),
             lm_torch_dtype=os.getenv("LLM_TORCH_DTYPE", "auto"),
             lm_stream=bool(os.getenv("LLM_STREAM", "1")),
             init_chat_prompt=os.getenv("LLM_INIT_CHAT_PROMPT", ""),

--- a/test/modules/speech/tts/test_spark.py
+++ b/test/modules/speech/tts/test_spark.py
@@ -266,8 +266,16 @@ class TestSparkTTS(unittest.TestCase):
             self.session.ctx.state["src_audio_path"] = self.src_audio_path
 
         self.session.ctx.state["tts_text"] = self.tts_text
-        self.session.ctx.state["temperature"] = 0.1
+        self.session.ctx.state["temperature"] = 0.9
         print(self.session.ctx)
+        # warmup
+        iter = self.tts.synthesize_sync(self.session)
+        for i, chunk in enumerate(iter):
+            pass
+        print(self.session.ctx)
+        if self.tts_tag == "tts_generator_spark":
+            assert "gen_global_token_ids" in self.session.ctx.state
+
         iter = self.tts.synthesize_sync(self.session)
         res = bytearray()
         times = []
@@ -280,6 +288,9 @@ class TestSparkTTS(unittest.TestCase):
         print(
             f"generate fisrt chunk({len(chunk)}) time: {times[0]} s, {len(res)} waveform cost time: {sum(times)} s, avg cost time: {sum(times)/len(res)}"
         )
+        print(self.session.ctx)
+        if self.tts_tag == "tts_generator_spark":
+            assert "gen_global_token_ids" in self.session.ctx.state
 
         stream_info = self.tts.get_stream_info()
         print(f"stream_info:{stream_info}")


### PR DESCRIPTION
feat:
- add concurrency tts test
cases:
```shell
# CONCURRENCY_CN=4
CONCURRENCY_CN=4 GENERATOR_ENGINE=vllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
CONCURRENCY_CN=4 GENERATOR_ENGINE=sglang TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
CONCURRENCY_CN=4 GENERATOR_ENGINE=trtllm TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
CONCURRENCY_CN=4 GENERATOR_ENGINE=trtllm_runner TTS_TAG=tts_generator_spark ACHATBOT_VERSION=0.0.9.post5 IMAGE_GPU=L40S modal run src/tts/run_generator_tts.py
```
- change run_generator_tts.sh add CONCURRENCE -c opt
```shell
bash run_generator_tts.sh -s run -t 'hello,你好，我是机器人。|万物之始,大道至简,衍化至繁。|君不见黄河之水天上来，奔流到海不复回。君不见高堂明镜悲白发，朝如青丝暮成雪。人生得意须尽欢，莫使金樽空对月。天生我材必有用，千金散尽还复来。' -g trtllm -d L40s -a tts_generator_spark -c 2 
bash run_generator_tts.sh -s run -g vllm -d L40s -a tts_generator_spark -c 4 
bash run_generator_tts.sh -s run -g sglang -d L40s -a tts_generator_spark -c 4 
bash run_generator_tts.sh -s run -g trtllm -d L40s -a tts_generator_spark -c 4 
bash run_generator_tts.sh -s run -g vllm -d L40s -a tts_generator_spark -c 8 
bash run_generator_tts.sh -s run -g sglang -d L40s -a tts_generator_spark -c 8 
bash run_generator_tts.sh -s run -g trtllm -d L40s -a tts_generator_spark -c 8
bash run_generator_tts.sh -s run -g vllm -d L40s -a tts_generator_spark -c 12 
bash run_generator_tts.sh -s run -g sglang -d L40s -a tts_generator_spark -c 12 
bash run_generator_tts.sh -s run -g trtllm -d L40s -a tts_generator_spark -c 12 
```

fix:
- spark_generator_tts use gen_global_token_ids for gender controler on the same session ctx

> [!tip]
> - 并发测试单独会话，没有设置语音克隆tts, 这里spark-tts控制control(性别音色，语速，语气强度)的配置是大概范围设置，为了保持音色控制，在测试时使用了初始预热时生成的control global token ids 来保持每个并发生成的语音音色的一致；
> - 至于流式输出平滑处理，可移至上层具体case去处理， 流式只输出对应生成音频块，未做fade in/out处理；
> - 如果想精准控制比例，可以改为按照控制比例来调整；
> - 如果设置语音克隆音频，则不会有生成的control global token ids，直接将音频waveform通过audio tokenizer encode来生成global token ids 和 semantic token ids。 具体见：https://github.com/ai-bot-pro/achatbot/pull/130