### PR TITLE
feat: add SmolVLM

### DIFF
--- a/deploy/modal/src/fastapi_webrtc_vision_bot_serve.py
+++ b/deploy/modal/src/fastapi_webrtc_vision_bot_serve.py
@@ -22,8 +22,7 @@ vision_bot_img = (
             "tts_edge,"
             "deep_translator,together_ai,"
             "queue"
-            # f"]=={achatbot_version}",
-            "]==0.0.12.dev9",
+            f"]=={achatbot_version}",
         ],
         extra_index_url=os.getenv("EXTRA_INDEX_URL", "https://pypi.org/simple/"),
     )

--- a/deploy/modal/src/fastapi_webrtc_vision_bot_serve.py
+++ b/deploy/modal/src/fastapi_webrtc_vision_bot_serve.py
@@ -22,7 +22,8 @@ vision_bot_img = (
             "tts_edge,"
             "deep_translator,together_ai,"
             "queue"
-            f"]=={achatbot_version}",
+            # f"]=={achatbot_version}",
+            "]==0.0.12.dev9",
         ],
         extra_index_url=os.getenv("EXTRA_INDEX_URL", "https://pypi.org/simple/"),
     )
@@ -150,6 +151,19 @@ class ContainerRuntimeConfig:
                     "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
                     "LLM_MODEL_NAME_OR_PATH": f'/root/.achatbot/models/{os.getenv("LLM_MODEL_NAME_OR_PATH", "llava-fastvithd_1.5b_stage3")}',
                     "MOBILE_CLIP_MODEL_CONFIG": "/root/.achatbot/models/mobileclip_l.json",
+                }
+            )
+        ),
+        "smolvlm": (
+            vision_bot_img.pip_install(
+                [
+                    f"achatbot[llm_transformers_manual_vision_smolvlm]=={achatbot_version}",
+                ],
+                extra_index_url=os.getenv("EXTRA_INDEX_URL", "https://pypi.org/simple/"),
+            ).env(
+                {
+                    "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+                    "LLM_MODEL_NAME_OR_PATH": f'/root/.achatbot/models/{os.getenv("LLM_MODEL_NAME_OR_PATH", "HuggingFaceTB/SmolVLM2-2.2B-Instruct")}',
                 }
             )
         ),

--- a/deploy/modal/src/llm/transformers/vlm/smolvlm.py
+++ b/deploy/modal/src/llm/transformers/vlm/smolvlm.py
@@ -1,0 +1,261 @@
+import os
+import subprocess
+from threading import Thread
+from time import perf_counter
+
+
+import modal
+
+
+app = modal.App("smolvlm")
+img = (
+    # https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags
+    modal.Image.from_registry(
+        "nvidia/cuda:12.6.1-cudnn-devel-ubuntu22.04",
+        add_python="3.10",
+    )
+    .apt_install("git", "git-lfs", "ffmpeg", "clang", "cmake", "ninja-build")
+    .pip_install(
+        "num2words",
+        "transformers",
+        "torch==2.6.0",
+        "torchaudio==2.6.0",
+        "torchvision==0.21.0",
+    )
+    .pip_install("wheel")
+    # https://github.com/Dao-AILab/flash-attention/releases/tag/v2.7.4.post1
+    .pip_install("flash-attn", extra_options="--no-build-isolation")
+    .env(
+        {
+            "PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True",
+            "TQDM_DISABLE": "1",
+            "LLM_MODEL": os.getenv("LLM_MODEL", "HuggingFaceTB/SmolVLM2-2.2B-Instruct"),
+        }
+    )
+)
+
+HF_MODEL_DIR = "/root/.achatbot/models"
+hf_model_vol = modal.Volume.from_name("models", create_if_missing=True)
+ASSETS_DIR = "/root/.achatbot/assets"
+assets_dir = modal.Volume.from_name("assets", create_if_missing=True)
+
+
+with img.imports():
+    import torch
+    from PIL import Image
+    from transformers import AutoProcessor, AutoModelForImageTextToText
+    from transformers.generation.streamers import TextIteratorStreamer
+
+
+@app.function(
+    gpu=os.getenv("IMAGE_GPU", None),
+    cpu=2.0,
+    retries=1,
+    image=img,
+    volumes={
+        HF_MODEL_DIR: hf_model_vol,
+        ASSETS_DIR: assets_dir,
+    },
+    timeout=1200,  # default 300s
+    scaledown_window=1200,
+    max_containers=1,
+)
+def run(func):
+    subprocess.run("nvidia-smi --version", shell=True)
+    subprocess.run("nvcc --version", shell=True)
+    gpu_prop = torch.cuda.get_device_properties("cuda")
+    print(gpu_prop)
+
+    func(gpu_prop)
+
+
+def print_model_params(model: torch.nn.Module, extra_info=""):
+    # print the number of parameters in the model
+    model_million_params = sum(p.numel() for p in model.parameters()) / 1e6
+    print(model)
+    print(f"{extra_info} {model_million_params} M parameters")
+
+
+def dump_model(gpu_prop):
+    for model_name in [
+        "HuggingFaceTB/SmolVLM2-2.2B-Instruct",
+    ]:
+        model_path = os.path.join(HF_MODEL_DIR, model_name)
+        processor = AutoProcessor.from_pretrained(model_path)
+        model = AutoModelForImageTextToText.from_pretrained(
+            model_path,
+            torch_dtype=torch.bfloat16,
+            attn_implementation="flash_attention_2" if gpu_prop.major >= 8 else None,
+        ).to("cuda")
+
+        model = model.eval()
+        print(f"{model.config=}")
+        print(f"{processor=}")
+        print_model_params(model, f"{model_name}")
+
+        del model
+        torch.cuda.empty_cache()
+
+
+# https://github.com/huggingface/smollm/tree/main/vision
+def predict(gpu_prop):
+    # Load model
+    MODEL_PATH = os.path.join(HF_MODEL_DIR, os.getenv("LLM_MODEL"))
+    processor = AutoProcessor.from_pretrained(MODEL_PATH)
+    model = AutoModelForImageTextToText.from_pretrained(
+        MODEL_PATH,
+        torch_dtype=torch.bfloat16,
+        _attn_implementation="flash_attention_2" if gpu_prop.major >= 8 else None,
+    ).to("cuda")
+
+    model = model.eval()
+    print(f"{model.config=}")
+    print(f"{processor=}")
+    # print(f"{model=}")
+
+    # Construct prompt
+    text = "请用中文描述图片内容"
+    # text = f"请用中文描述图片内容，不要使用Markdown格式回复。"
+
+    # don't to chat with smolvlm, just do vision task
+    # text = "Please reply to my message in Chinese simplified(简体中文), don't use Markdown format. 你好"
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg",
+                },
+                {"type": "text", "text": text},
+            ],
+        },
+    ]
+
+    inputs = processor.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_dict=True,
+        return_tensors="pt",
+    ).to(model.device, dtype=torch.bfloat16)
+    for key, value in inputs.items():
+        print(f"{key}: {value.shape=}")
+    input_ids = inputs["input_ids"]
+    prompt = processor.decode(input_ids[0])
+    print(f"{prompt=}")
+
+    generated_ids = model.generate(
+        **inputs,
+        do_sample=False,
+        # 如果要使用重复惩罚, 虽然会解决重复, 但是会降低生成质量
+        #  bad case: 在椒花的突出体部上, 有一个尖细而干净的电触噬兽在吸收野生产成员. 被目标传通了一条线急忟利场非市主义人类对至代表力量和发展术预示所形成的弗雾化作为秋季戈巴斐協筝歌曲、旭辰四星点时间以前到现在是最大限度控制整个社区许可下载后立法定行列应执行这项技能指导方便分析管理模型的研修奖得名委员会负担问题； 查看网址：www.shen
+        # repetition_penalty=1.5,
+        max_new_tokens=256,
+    )
+    print(f"{generated_ids.shape=}")
+    generated_text = processor.decode(
+        generated_ids[0][len(input_ids[0]) :],
+        # skip_special_tokens=True,
+    )
+    print(generated_text)
+
+
+# https://github.com/huggingface/smollm/tree/main/vision
+def predict_stream(gpu_prop):
+    # Load model
+    MODEL_PATH = os.path.join(HF_MODEL_DIR, os.getenv("LLM_MODEL"))
+    processor = AutoProcessor.from_pretrained(MODEL_PATH)
+    model = AutoModelForImageTextToText.from_pretrained(
+        MODEL_PATH,
+        torch_dtype=torch.bfloat16,
+        _attn_implementation="flash_attention_2" if gpu_prop.major >= 8 else None,
+    ).to("cuda")
+
+    model = model.eval()
+    print(f"{model.config=}")
+    print(f"{processor=}")
+    # print(f"{model=}")
+
+    # Construct prompt
+    text = "请用中文描述图片内容"
+    # text = "Please reply to my message in Chinese simplified(简体中文), don't use Markdown format. 描述下图片内容"
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg",
+                },
+                {"type": "text", "text": text},
+            ],
+        },
+    ]
+
+    inputs = processor.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_dict=True,
+        return_tensors="pt",
+    ).to(model.device, dtype=torch.bfloat16)
+    for key, value in inputs.items():
+        print(f"{key}: {value.shape=}")
+    input_ids = inputs["input_ids"]
+    prompt = processor.decode(input_ids[0])
+    print(f"{prompt=}")
+
+    for i in range(3):
+        streamer = TextIteratorStreamer(
+            tokenizer=processor, skip_prompt=True, skip_special_tokens=True
+        )
+        # don't to do sampling
+        generation_kwargs = dict(
+            **inputs,
+            do_sample=False,
+            # do_sample=True,
+            # temperature=0.2,
+            # top_p=None,
+            # num_beams=1,
+            # repetition_penalty=1.5,
+            max_new_tokens=1024,
+            use_cache=True,
+            streamer=streamer,
+        )
+        thread = Thread(target=model.generate, kwargs=generation_kwargs)
+        thread.start()
+        generated_text = ""
+        start = perf_counter()
+        times = []
+        for new_text in streamer:
+            times.append(perf_counter() - start)
+            print(new_text, end="", flush=True)
+            generated_text += new_text
+            start = perf_counter()
+        print(f"\n{i}. {generated_text=} TTFT: {times[0]:.2f}s total time: {sum(times):.2f}s")
+
+
+"""
+IMAGE_GPU=T4 modal run src/llm/transformers/vlm/smolvlm.py --task dump_model
+IMAGE_GPU=T4 modal run src/llm/transformers/vlm/smolvlm.py --task predict
+IMAGE_GPU=T4 modal run src/llm/transformers/vlm/smolvlm.py --task predict_stream
+
+IMAGE_GPU=L4 modal run src/llm/transformers/vlm/smolvlm.py --task predict
+IMAGE_GPU=L4 modal run src/llm/transformers/vlm/smolvlm.py --task predict_stream
+"""
+
+
+@app.local_entrypoint()
+def main(task: str = "dump_model"):
+    tasks = {
+        "dump_model": dump_model,
+        "predict": predict,
+        "predict_stream": predict_stream,
+    }
+    if task not in tasks:
+        raise ValueError(f"task {task} not found")
+    print(f"running task {task}")
+    run.remote(tasks[task])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ speech_waker = ["achatbot[porcupine_wakeword]"]
 # vad module tag -> pkgs
 pyannote_vad = ["pyannote.audio~=3.2.0"]
 webrtcvad = ["webrtcvad~=2.0.10"]
-silero_vad = ["torch", "torchaudio"]
+silero_vad = ["achatbot[torch_vision_audio]"]
 webrtc_silero_vad = ["achatbot[webrtcvad,silero_vad]"]
 speech_vad = ["achatbot[pyannote_vad,webrtcvad,silero_vad]"]
 
@@ -203,12 +203,10 @@ flashinfer-python = ["flashinfer-python==0.2.3"]
 # vision llm
 llm_transformers_manual_vision = [
     #"transformers@git+https://github.com/huggingface/transformers",
-    "transformers~=4.50.3",
+    "transformers",
     "qwen-vl-utils",
     "av",
-    "torch~=2.2.2",
-    "torchaudio~=2.2.2",
-    "torchvision~=0.17.2",
+    "achatbot[torch_vision_audio]",
 ]
 llm_transformers_manual_vision_qwen = [
     "achatbot[llm_transformers_manual_vision]",
@@ -255,6 +253,10 @@ llm_transformers_manual_vision_fastvlm = [
     "einops==0.6.1",
     "einops-exts==0.0.4",
     "timm==1.0.15",
+]
+llm_transformers_manual_vision_smolvlm = [
+    "achatbot[llm_transformers_manual_vision]",
+    "num2words",
 ]
 
 # voice llm

--- a/src/core/llm/__init__.py
+++ b/src/core/llm/__init__.py
@@ -45,6 +45,8 @@ class LLMEnvInit:
             from .transformers import manual_vision_kimi
         elif "llm_transformers_manual_vision_fastvlm" == tag:
             from .transformers import manual_vision_fastvlm
+        elif "llm_transformers_manual_vision_smollm" == tag:
+            from .transformers import manual_vision_smolvlm
         elif "llm_transformers_manual_vision_janus_flow" == tag:
             from .transformers import manual_vision_img_janus_flow
         elif "llm_transformers_manual_image_janus_flow" == tag:
@@ -426,6 +428,7 @@ class LLMEnvInit:
         "llm_transformers_manual": get_llm_transformers_args,
         "llm_transformers_pipeline": get_llm_transformers_args,
         "llm_transformers_manual_vision_qwen": get_llm_transformers_args,
+        "llm_transformers_manual_vision_smollm": get_llm_transformers_args,
         "llm_transformers_manual_vision_qwen2_5": get_llm_transformers_args,
         "llm_transformers_manual_vision_llama": get_llm_transformers_args,
         "llm_transformers_manual_vision_molmo": get_llm_transformers_args,

--- a/src/core/llm/transformers/manual_vision_smolvlm.py
+++ b/src/core/llm/transformers/manual_vision_smolvlm.py
@@ -1,0 +1,160 @@
+import logging
+from threading import Thread
+from PIL import Image
+from time import perf_counter
+
+try:
+    from transformers import AutoProcessor, TextIteratorStreamer, AutoModelForImageTextToText
+    import torch
+
+except ModuleNotFoundError as e:
+    logging.error(f"Exception: {e}")
+    logging.error(
+        "In order to use Smol-VLM, you need to `pip install achatbot[llm_transformers_manual_vision_smolvlm]`"
+    )
+    raise Exception(f"Missing module: {e}")
+
+
+from src.common.utils.helper import get_device, print_model_params
+from src.common.random import set_all_random_seed
+from src.common.chat_history import ChatHistory
+from src.common.session import Session
+from src.types.speech.language import TO_LLM_LANGUAGE
+from src.types.llm.transformers import TransformersLMArgs
+from .base import TransformersBaseLLM
+
+
+class TransformersManualVisionSmolLM(TransformersBaseLLM):
+    TAG = "llm_transformers_manual_vision_smollm"
+
+    def __init__(self, **args) -> None:
+        self.args = TransformersLMArgs(**args)
+        gpu_prop = torch.cuda.get_device_properties("cuda")
+
+        if self.args.lm_device_map:
+            self._model = AutoModelForImageTextToText.from_pretrained(
+                self.args.lm_model_name_or_path,
+                torch_dtype=torch.bfloat16,
+                #!NOTE: https://github.com/huggingface/transformers/issues/20896
+                # device_map for multi cpu/gpu with accelerate
+                device_map=self.args.lm_device_map,
+                attn_implementation="flash_attention_2" if gpu_prop.major >= 8 else None,
+                trust_remote_code=True,
+            ).eval()
+        else:
+            self._model = (
+                AutoModelForImageTextToText.from_pretrained(
+                    self.args.lm_model_name_or_path,
+                    torch_dtype=torch.bfloat16,
+                    attn_implementation=self.args.lm_attn_impl,
+                    trust_remote_code=True,
+                )
+                .eval()
+                .to(self.args.lm_device)
+            )
+
+        print_model_params(self._model, self.TAG)
+        self._tokenizer = AutoProcessor.from_pretrained(self.args.lm_model_name_or_path)
+
+        self.warmup()
+
+    def warmup(self):
+        if self.args.warmup_steps <= 0:
+            return
+        dummy_input_text = self.args.warnup_prompt
+        dummy_pil_image = Image.new("RGB", (100, 100), color="white")
+        dummy_msgs = [
+            {
+                "role": self.args.user_role,
+                "content": [
+                    {"type": "text", "text": dummy_input_text},
+                    {"type": "image", "image": dummy_pil_image},
+                ],
+            }
+        ]
+
+        inputs = self._tokenizer.apply_chat_template(
+            dummy_msgs,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        ).to(
+            self._model.device,
+            dtype=torch.bfloat16,
+        )
+
+        streamer = TextIteratorStreamer(self._tokenizer, skip_prompt=True, skip_special_tokens=True)
+
+        warmup_gen_kwargs = dict(
+            **inputs,
+            streamer=streamer,
+            do_sample=False,
+            min_new_tokens=self.args.lm_gen_min_new_tokens,
+            max_new_tokens=self.args.lm_gen_max_new_tokens,
+        )
+
+        self._warmup(
+            target=self._model.generate,
+            kwargs=warmup_gen_kwargs,
+            streamer=streamer,
+        )
+
+    def generate(self, session: Session, **kwargs):
+        seed = kwargs.get("seed", self.args.lm_gen_seed)
+        set_all_random_seed(seed)
+
+        prompt = session.ctx.state["prompt"]
+        assert len(prompt) > 0
+        text = prompt[0].get("text", "")
+        text = self.args.init_chat_prompt + text
+        if (
+            not self.args.lm_language_code
+            or self.args.lm_language_code not in TO_LLM_LANGUAGE.keys()
+        ):
+            self.args.lm_language_code = "zh"
+        if self.args.lm_language_code == "zh":
+            # NOTE: smol-vlm just do vision task, don't support to chat (Q/A task) need sft and do Pareto Front
+            text = (
+                self.args.init_chat_prompt if self.args.init_chat_prompt else "请用中文描述图片内容"
+            )
+        prompt[0]["text"] = text
+
+        message = {"role": self.args.user_role, "content": prompt}
+        inputs = self._tokenizer.apply_chat_template(
+            [message],
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        ).to(
+            self._model.device,
+            dtype=torch.bfloat16,
+        )
+
+        streamer = TextIteratorStreamer(self._tokenizer, skip_prompt=True, skip_special_tokens=True)
+
+        generation_kwargs = dict(
+            **inputs,
+            streamer=streamer,
+            do_sample=False,
+            min_new_tokens=kwargs.get("min_new_tokens", self.args.lm_gen_min_new_tokens),
+            max_new_tokens=kwargs.get("max_new_tokens", self.args.lm_gen_max_new_tokens),
+            # 如果要使用重复惩罚, 虽然会解决重复, 但是会降低生成质量
+            #  bad case: 在椒花的突出体部上, 有一个尖细而干净的电触噬兽在吸收野生产成员. 被目标传通了一条线急忟利场非市主义人类对至代表力量和发展术预示所形成的弗雾化作为秋季戈巴斐協筝歌曲、旭辰四星点时间以前到现在是最大限度控制整个社区许可下载后立法定行列应执行这项技能指导方便分析管理模型的研修奖得名委员会负担问题； 查看网址：www.shen
+            # repetition_penalty=1.5,
+            use_cache=True,
+        )
+        thread = Thread(target=self._model.generate, kwargs=generation_kwargs)
+        thread.start()
+
+        generated_text = ""
+        start = perf_counter()
+        times = []
+        for new_text in streamer:
+            times.append(perf_counter() - start)
+            generated_text += new_text
+            yield new_text
+            start = perf_counter()
+        logging.info(f"{generated_text=} TTFT: {times[0]:.4f}s total time: {sum(times):.4f}s")
+        torch.cuda.empty_cache()

--- a/src/core/llm/transformers/manual_vision_smolvlm.py
+++ b/src/core/llm/transformers/manual_vision_smolvlm.py
@@ -141,7 +141,6 @@ class TransformersManualVisionSmolLM(TransformersBaseLLM):
             min_new_tokens=kwargs.get("min_new_tokens", self.args.lm_gen_min_new_tokens),
             max_new_tokens=kwargs.get("max_new_tokens", self.args.lm_gen_max_new_tokens),
             # 如果要使用重复惩罚, 虽然会解决重复, 但是会降低生成质量
-            #  bad case: 在椒花的突出体部上, 有一个尖细而干净的电触噬兽在吸收野生产成员. 被目标传通了一条线急忟利场非市主义人类对至代表力量和发展术预示所形成的弗雾化作为秋季戈巴斐協筝歌曲、旭辰四星点时间以前到现在是最大限度控制整个社区许可下载后立法定行列应执行这项技能指导方便分析管理模型的研修奖得名委员会负担问题； 查看网址：www.shen
             # repetition_penalty=1.5,
             use_cache=True,
         )

--- a/src/processors/vision/vision_processor.py
+++ b/src/processors/vision/vision_processor.py
@@ -70,7 +70,7 @@ class VisionProcessor(VisionProcessorBase):
         ):  # transformers vision FastVLM
             async for item in self._run_imgs_text_vision(frame):
                 yield item
-        else:  # qwen vision (kimi vision) is default, nice vision prompt
+        else:  # smolvlm, qwen vision (kimi vision) is default, nice vision prompt
             async for item in self._run_vision(frame):
                 yield item
 


### PR DESCRIPTION
smolLM2:
<img width="906" alt="image" src="https://github.com/user-attachments/assets/88f9981a-e7ef-4ec4-8f34-6b0a9c66e3fe" />

smolVLM:
<img width="888" alt="image" src="https://github.com/user-attachments/assets/ca03cf53-c51c-4168-8265-f7ed0626db6f" />


feat:
- add manual_vision_smolvlm and DailyDescribeVisionSmolvlmBot
- add smolvlm fastapi_webrtc_vision_bot_serve

test:
```shell
IMAGE_GPU=T4 modal run src/llm/transformers/vlm/smolvlm.py --task dump_model
IMAGE_GPU=T4 modal run src/llm/transformers/vlm/smolvlm.py --task predict
IMAGE_GPU=T4 modal run src/llm/transformers/vlm/smolvlm.py --task predict_stream

IMAGE_GPU=L4 modal run src/llm/transformers/vlm/smolvlm.py --task predict
IMAGE_GPU=L4 modal run src/llm/transformers/vlm/smolvlm.py --task predict_stream
```
run fastapi_webrtc_vision_bot_serve use smolvlm 
```shell
ACHATBOT_VERSION=0.0.12 IMAGE_NAME=smolvlm IMAGE_CONCURRENT_CN=1 IMAGE_GPU=T4 modal serve src/fastapi_webrtc_vision_bot_serve.py

ACHATBOT_VERSION=0.0.12 IMAGE_NAME=smolvlm IMAGE_CONCURRENT_CN=1 IMAGE_GPU=L4 modal serve src/fastapi_webrtc_vision_bot_serve.py
```
startup  daily room llm_transformers_manual_vision_smollm bot
```shell
curl --location 'https://weedge--fastapi-webrtc-vision-smolvlm-bot-srv-app-dev.modal.run/bot_join/chat-room/DailyDescribeVisionBot' \
--header 'Content-Type: application/json' \
--data '{
    "chat_bot_name": "DailyDescribeVisionBot",
    "room_name": "chat-room",
    "room_url": "",
    "token": "",
    "services": {
        "pipeline": "achatbot",
        "vad": "silero",
        "asr": "sense_voice",
        "llm": "llm_transformers_manual_vision_smollm",
        "tts": "edge"
    },
    "config": {
        "vad": {
            "tag": "silero_vad_analyzer",
            "args": {
                "stop_secs": 0.7
            }
        },
        "asr": {
            "tag": "sense_voice_asr",
            "args": {
                "language": "zn",
                "model_name_or_path": "/root/.achatbot/models/FunAudioLLM/SenseVoiceSmall"
            }
        },
        "llm": {
            "tag": "llm_transformers_manual_vision_smollm",
            "args": {
                "lm_device": "cuda",
                "lm_torch_dtype": "bfloat16",
                "lm_model_name_or_path": "/root/.achatbot/models/HuggingFaceTB/SmolVLM2-2.2B-Instruct",
                "init_chat_prompt": "请用中文交流",
                "model_type": "chat_completion"
            },
            "language": "zh"
        },
        "tts": {
            "tag": "tts_edge",
            "args": {
                "voice_name": "zh-CN-YunjianNeural",
                "language": "zh",
                "gender": "Male"
            }
        }
    },
    "config_list": []
}'
```
deploy serve
```
ACHATBOT_VERSION=0.0.12 IMAGE_NAME=smolvlm IMAGE_CONCURRENT_CN=1 IMAGE_GPU=T4 modal deploy -e achatbot src/fastapi_webrtc_vision_bot_serve.py
```

---

podcast: 
- SmolVLM: https://podcast-997.pages.dev/podcast/ee5c731f61314396a0e2d9011156a67e
- SmolLM2: https://podcast-997.pages.dev/podcast/525fb883c248478c803e1f037a7e5ced

---

> [!TIP]
> - image encoder: [the shape-optimized SigLIP-so400m](https://huggingface.co/google/siglip-so400m-patch14-384)
> - text decoder: [SmolLM2-1.7B-Instruct](https://huggingface.co/HuggingFaceTB/SmolLM2-1.7B-Instruct)
> - 和fastvlm 一样 主要应用在端侧的模型，但是感觉推理效果（速度和推理质量）不如fastvlm， 而且fastvlm评估相对全面；
> - 但是SmolVLM加入 Video 数据集进行训练和评估；
> - Apple App HuggingSnap: https://apps.apple.com/us/app/huggingsnap/id6742157364
> - space: https://huggingface.co/spaces/HuggingFaceTB/SmolVLM

> [!NOTE]
> - smolvlm  主要用于 vision task, 对于文本聊天任务，中文支持不够好，有时会出现复读现象。
> - 复读现象（重复回答），虽然可以加入重复惩罚，但是生成质量很差。
> - 对中文支持不够好，要求用中文回答，有时会回复英文。
> - 聊天QA任务的支持，需要进行SFT，对整体任务进行评估（注意 Pareto Front）。
> - 由于使用的HF自己训练的模型（smolLM2）作为LLM骨干，在中文数据的训练上不如qwen2系列。
> - 对于中文任务，lm_head 输出的logits 不要使用 sampling(采样，do_sample=True)，否则会出现答非所问的badcase。

---
# reference
- ⭐️ [2023.3 Sigmoid Loss for Language Image Pre-Training](https://arxiv.org/abs/2303.15343) | [paper code](https://github.com/google-research/big_vision)
- [Idefics3](https://huggingface.co/HuggingFaceM4/Idefics3-8B-Llama3): [2024.8 Building and better understanding vision-language models: insights and future directions](https://arxiv.org/abs/2408.12637) | [paper code](https://github.com/huggingface/transformers/tree/main/src/transformers/models/idefics3)
- [2025.2 SmolLM2: When Smol Goes Big -- Data-Centric Training of a Small Language Model](https://arxiv.org/abs/2502.02737v1)(LLama2 arch GQA) | [paper code](https://github.com/huggingface/smollm)
- [2025.3 SmolDocling: An ultra-compact vision-language model for end-to-end multi-modal document conversion](https://arxiv.org/abs/2503.11576) | [paper code](https://github.com/docling-project/docling)
- [2025.4 SmolVLM: Redefining small and efficient multimodal models](https://arxiv.org/abs/2504.05299) | [paper code](https://github.com/huggingface/smollm/tree/main/vision)
- fine tuning smolvlm instruct: https://huggingface.co/learn/cookbook/fine_tuning_vlm_dpo_smolvlm_instruct
- https://huggingface.co/blog/smolvlm2
