### PR TITLE
feat: add SmallWebRTCConnection and  SmallWebRTCTransport  to run SmallWebrtcBot with signaling http server

### DIFF
--- a/src/cmd/bots/__init__.py
+++ b/src/cmd/bots/__init__.py
@@ -4,6 +4,7 @@ from src.common.register import Register
 
 register_ai_room_bots = Register("ai-room-bots")
 register_ai_fastapi_ws_bots = Register("fastapi-ws-bots")
+register_ai_small_webrtc_bots = Register("small-webrtc-bots")
 
 
 class BotInfo(BaseModel):
@@ -292,6 +293,15 @@ def import_fastapi_websocket_bots(bot_name: str = "DummyBot"):
 
     if "FastapiWebsocketMoshiVoiceBot" in bot_name:
         from .voice import fastapi_websocket_moshi_bot
+
+        return True
+
+    return False
+
+
+def import_small_webrtc_bots(bot_name: str = "DummyBot"):
+    if "SmallWebrtcBot" == bot_name:
+        from . import small_webrtc_bot
 
         return True
 

--- a/src/cmd/bots/base_small_webrtc.py
+++ b/src/cmd/bots/base_small_webrtc.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Any
+
+from fastapi import WebSocket
+from apipeline.frames.control_frames import EndFrame
+
+from src.services.webrtc_peer_connection import SmallWebRTCConnection
+from src.cmd.bots.base import AIBot
+from src.transports.small_webrtc import SmallWebRTCTransport
+
+
+class SmallWebrtcAIBot(AIBot):
+    def __init__(self, webrtc_connection: SmallWebRTCConnection | None = None, **args) -> None:
+        super().__init__(**args)
+        self._webrtc_connection = webrtc_connection
+
+    def set_webrtc_connection(self, webrtc_connection: WebSocket):
+        self._webrtc_connection = webrtc_connection
+
+    def regisiter_event(self, transport: SmallWebRTCTransport):
+        transport.add_event_handler(
+            "on_client_connected",
+            self.on_client_connected,
+        )
+        transport.add_event_handler(
+            "on_client_disconnected",
+            self.on_client_disconnected,
+        )
+        transport.add_event_handler(
+            "on_app_message",
+            self.on_app_message,
+        )
+
+    async def on_client_connected(
+        self,
+        transport: SmallWebRTCTransport,
+        connection: SmallWebRTCConnection,
+    ):
+        logging.info(
+            f"on_client_connected callee id:{connection.pc_id} caller: {connection.pc.remoteDescription}"
+        )
+
+    async def on_client_disconnected(
+        self,
+        transport: SmallWebRTCTransport,
+        connection: SmallWebRTCConnection,
+    ):
+        logging.info(
+            f"on_client_disconnected callee id:{connection.pc_id} caller: {connection.pc.remoteDescription}"
+        )
+        if self.task is not None:
+            await self.task.queue_frame(EndFrame())
+
+    async def on_app_message(
+        self,
+        transport: SmallWebRTCTransport,
+        message: Any,
+    ):
+        logging.info(f"on_app_message recieved message: {message}")

--- a/src/cmd/bots/bot_loader.py
+++ b/src/cmd/bots/bot_loader.py
@@ -5,11 +5,20 @@ import os
 import pathlib
 from typing import Literal
 
-from src.cmd.bots import import_bots, import_fastapi_websocket_bots, import_websocket_bots
+from src.cmd.bots import (
+    import_bots,
+    import_fastapi_websocket_bots,
+    import_websocket_bots,
+    import_small_webrtc_bots,
+)
 from src.cmd.bots.base import AIBot
 from src.common.types import BotRunArgs
 from src.cmd.bots.run import RunBotInfo
-from src.cmd.bots import register_ai_fastapi_ws_bots, register_ai_room_bots
+from src.cmd.bots import (
+    register_ai_fastapi_ws_bots,
+    register_ai_room_bots,
+    register_ai_small_webrtc_bots,
+)
 
 
 """
@@ -17,7 +26,7 @@ from src.cmd.bots import register_ai_fastapi_ws_bots, register_ai_room_bots
 """
 
 
-async def load_bot_config_from_local(file_path: str):
+def load_bot_config_from_local(file_path: str):
     bot_config = {}
     with open(file_path, "r") as f:
         bot_config = json.load(f)
@@ -39,7 +48,7 @@ class BotLoader:
     async def load_bot(
         local_file_path: str | pathlib.PosixPath,
         is_re_init=False,
-        bot_type: Literal["room_bot", "ws_bot", "fastapi_ws_bot"] = "room_bot",
+        bot_type: Literal["room_bot", "ws_bot", "fastapi_ws_bot", "small_webrtc_bot"] = "room_bot",
     ) -> AIBot:
         """
         load once from str or pathlib.PosixPath(for container volume)
@@ -52,7 +61,7 @@ class BotLoader:
             logging.error(f"config_path: {local_file_path} not found")
             raise FileNotFoundError
 
-        bot_info = await load_bot_config_from_local(file_path=local_file_path)
+        bot_info = load_bot_config_from_local(file_path=local_file_path)
         bot_args = BotRunArgs(
             bot_name=bot_info.chat_bot_name,
             bot_config=bot_info.config,
@@ -106,6 +115,19 @@ class BotLoader:
 
                     run_bot = register_ai_fastapi_ws_bots[bot_info.chat_bot_name](
                         websocket=None, **vars(bot_args)
+                    )
+                case "small_webrtc_bot":
+                    if import_small_webrtc_bots(bot_info.chat_bot_name) is False:
+                        detail = f"un import bot: {bot_info.chat_bot_name}"
+                        raise Exception(detail)
+
+                    logging.info(f"register bots: {register_ai_small_webrtc_bots.items()}")
+                    if bot_info.chat_bot_name not in register_ai_small_webrtc_bots:
+                        detail = f"bot {bot_info.chat_bot_name} don't exist"
+                        raise Exception(detail)
+
+                    run_bot = register_ai_small_webrtc_bots[bot_info.chat_bot_name](
+                        webrtc_connection=None, **vars(bot_args)
                     )
             BotLoader.run_bots[bot_info.chat_bot_name] = run_bot
 

--- a/src/cmd/webrtc/signaling_bot_server.py
+++ b/src/cmd/webrtc/signaling_bot_server.py
@@ -1,0 +1,117 @@
+# signaling fastapi http service + small webrtc bot (fastapi backgound task)
+
+import os
+import argparse
+import asyncio
+import sys
+import logging
+from contextlib import asynccontextmanager
+import traceback
+from typing import Dict
+
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import BackgroundTasks, FastAPI
+
+from src.cmd.bots.base import AIBot
+from src.services.webrtc_peer_connection import SmallWebRTCConnection, IceServer
+from src.cmd.bots.bot_loader import BotLoader
+from src.common.types import CONFIG_DIR
+
+
+# Load environment variables
+load_dotenv(override=True)
+
+
+run_bot: AIBot = None
+# Store connections by pc_id
+pcs_map: Dict[str, SmallWebRTCConnection] = {}
+
+
+ice_servers = [
+    IceServer(
+        urls="stun:stun.l.google.com:19302",
+    )
+]
+
+
+# https://fastapi.tiangolo.com/advanced/events/#lifespan
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global run_bot
+    try:
+        # load model before running
+        run_bot = await BotLoader.load_bot(args.f, bot_type="small_webrtc_bot")
+    except Exception as e:
+        print(e)
+        traceback.print_exc()
+
+    print(f"load bot {run_bot} success")
+
+    yield  # Run app
+
+    # app life end to clear resources
+    coros = [pc.disconnect() for pc in pcs_map.values()]
+    await asyncio.gather(*coros)
+    pcs_map.clear()
+
+    print(f"clear success")
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.post("/api/offer")
+async def handle_offer(request: dict, background_tasks: BackgroundTasks):
+    pc_id = request.get("pc_id")
+    logging.info(f"request pc_id: {pc_id}")
+
+    if pc_id and pc_id in pcs_map:
+        connection = pcs_map[pc_id]
+        logging.info(f"Reusing existing connection for pc_id: {pc_id}")
+        await connection.renegotiate(
+            sdp=request["sdp"], type=request["type"], restart_pc=request.get("restart_pc", False)
+        )
+    else:
+        connection = SmallWebRTCConnection(ice_servers)
+        await connection.initialize(sdp=request["sdp"], type=request["type"])
+
+        @connection.event_handler("closed")
+        async def handle_disconnected(webrtc_connection: SmallWebRTCConnection):
+            logging.info(f"Discarding peer connection for pc_id: {webrtc_connection.pc_id}")
+            pcs_map.pop(webrtc_connection.pc_id, None)
+
+        run_bot.set_webrtc_connection(connection)
+        background_tasks.add_task(run_bot.try_run)
+
+    answer = connection.get_answer()
+    logging.info(f"answer pc_id: {answer['pc_id']}")
+    # Updating the peer connection inside the map
+    pcs_map[answer["pc_id"]] = connection
+
+    return answer
+
+
+"""
+python -m src.cmd.webrtc.signaling_bot_server -f config/bots/small_webrtc_server_bot.json 
+"""
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="WebRTC Signaling Bot Server")
+    parser.add_argument(
+        "--host", default="localhost", help="Host for HTTP server (default: localhost)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=4321, help="Port for HTTP server (default: 4321)"
+    )
+    parser.add_argument("--reload", action="store_true", help="Reload code on change")
+    parser.add_argument(
+        "-f",
+        type=str,
+        default=os.path.join(CONFIG_DIR, "bots/dummy_bot.json"),
+        help="Bot configuration json file",
+    )
+
+    args = parser.parse_args()
+
+    uvicorn.run(app, host=args.host, port=args.port, reload=args.reload)

--- a/src/processors/small_webrtc_input_transport_processor.py
+++ b/src/processors/small_webrtc_input_transport_processor.py
@@ -1,0 +1,126 @@
+import logging
+from typing import Any
+
+
+from apipeline.frames import Frame, StartFrame, EndFrame, CancelFrame
+from apipeline.processors.frame_processor import FrameDirection
+
+from src.types.frames import TransportMessageFrame, UserImageRawFrame, UserImageRequestFrame
+from src.common.types import AudioCameraParams
+from src.services.small_webrtc_client import SmallWebRTCClient
+from src.processors.audio_input_processor import AudioVADInputProcessor
+
+
+class SmallWebRTCInputProcessor(AudioVADInputProcessor):
+    def __init__(
+        self,
+        client: SmallWebRTCClient,
+        params: AudioCameraParams,
+        **kwargs,
+    ):
+        super().__init__(params, **kwargs)
+        self._client = client
+        self._params = params
+        self._receive_audio_task = None
+        self._receive_video_task = None
+        self._image_requests = {}
+
+        # Whether we have seen a StartFrame already.
+        self._initialized = False
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, UserImageRequestFrame):
+            await self.request_participant_image(frame)
+
+    async def start(self, frame: StartFrame):
+        await super().start(frame)
+
+        if self._initialized:
+            return
+
+        self._initialized = True
+
+        await self._client.setup(self._params, frame)
+        await self._client.connect()
+        if not self._receive_audio_task and self._params.audio_in_enabled:
+            self._receive_audio_task = self.create_task(self._receive_audio())
+        if not self._receive_video_task and self._params.video_in_enabled:
+            self._receive_video_task = self.create_task(self._receive_video())
+        await self.set_transport_ready(frame)
+
+    async def _stop_tasks(self):
+        if self._receive_audio_task:
+            await self.cancel_task(self._receive_audio_task)
+            self._receive_audio_task = None
+        if self._receive_video_task:
+            await self.cancel_task(self._receive_video_task)
+            self._receive_video_task = None
+
+    async def stop(self, frame: EndFrame):
+        await super().stop(frame)
+        await self._stop_tasks()
+        await self._client.disconnect()
+
+    async def cancel(self, frame: CancelFrame):
+        await super().cancel(frame)
+        await self._stop_tasks()
+        await self._client.disconnect()
+
+    async def _receive_audio(self):
+        try:
+            async for audio_frame in self._client.read_audio_frame():
+                if audio_frame:
+                    await self.push_audio_frame(audio_frame)
+
+        except Exception as e:
+            logging.error(f"{self} exception receiving data: {e.__class__.__name__} ({e})")
+
+    async def _receive_video(self):
+        try:
+            async for video_frame in self._client.read_video_frame():
+                if video_frame:
+                    await self.push_video_frame(video_frame)
+
+                    # Check if there are any pending image requests and create UserImageRawFrame
+                    if self._image_requests:
+                        for req_id, request_frame in list(self._image_requests.items()):
+                            # Create UserImageRawFrame using the current video frame
+                            image_frame = UserImageRawFrame(
+                                user_id=request_frame.user_id,
+                                request=request_frame,
+                                image=video_frame.image,
+                                size=video_frame.size,
+                                format=video_frame.format,
+                            )
+                            # Push the frame to the pipeline
+                            await self.push_video_frame(image_frame)
+                            # Remove from pending requests
+                            del self._image_requests[req_id]
+
+        except Exception as e:
+            logging.error(f"{self} exception receiving data: {e.__class__.__name__} ({e})")
+
+    async def push_app_message(self, message: Any):
+        logging.debug(f"Received app message inside SmallWebRTCInputTransport  {message}")
+        frame = TransportMessageFrame(message=message, urgent=True)
+        await self.push_frame(frame)
+
+    # Add this method similar to DailyInputTransport.request_participant_image
+    async def request_participant_image(self, frame: UserImageRequestFrame):
+        """Requests an image frame from the participant's video stream.
+
+        When a UserImageRequestFrame is received, this method will store the request
+        and the next video frame received will be converted to a UserImageRawFrame.
+        """
+        logging.debug(f"Requesting image from participant: {frame.user_id}")
+
+        # Store the request
+        request_id = f"{frame.function_name}:{frame.tool_call_id}"
+        self._image_requests[request_id] = frame
+
+        # If we're not already receiving video, try to get a frame now
+        if not self._receive_video_task and self._params.video_in_enabled:
+            # Start video reception if it's not already running
+            self._receive_video_task = self.create_task(self._receive_video())

--- a/src/processors/small_webrtc_output_transport_processor.py
+++ b/src/processors/small_webrtc_output_transport_processor.py
@@ -1,0 +1,56 @@
+import logging
+
+from apipeline.frames import StartFrame, EndFrame, CancelFrame
+
+from src.types.frames.data_frames import (
+    OutputAudioRawFrame,
+    OutputImageRawFrame,
+    TransportMessageFrame,
+)
+from src.common.types import AudioCameraParams
+from src.services.small_webrtc_client import SmallWebRTCClient
+from src.processors.audio_camera_output_processor import AudioCameraOutputProcessor
+
+
+class SmallWebRTCOutputProcessor(AudioCameraOutputProcessor):
+    def __init__(
+        self,
+        client: SmallWebRTCClient,
+        params: AudioCameraParams,
+        **kwargs,
+    ):
+        super().__init__(params, **kwargs)
+        self._client = client
+        self._params = params
+
+        # Whether we have seen a StartFrame already.
+        self._initialized = False
+
+    async def start(self, frame: StartFrame):
+        await super().start(frame)
+
+        if self._initialized:
+            return
+
+        self._initialized = True
+
+        await self._client.setup(self._params, frame)
+        await self._client.connect()
+        await self.set_transport_ready(frame)
+
+    async def stop(self, frame: EndFrame):
+        await super().stop(frame)
+        await self._client.disconnect()
+
+    async def cancel(self, frame: CancelFrame):
+        await super().cancel(frame)
+        await self._client.disconnect()
+
+    async def send_message(self, frame: TransportMessageFrame):
+        await self._client.send_message(frame)
+
+    async def write_audio_frame(self, frame: OutputAudioRawFrame):
+        await self._client.write_audio_frame(frame)
+
+    async def write_video_frame(self, frame: OutputImageRawFrame):
+        await self._client.write_video_frame(frame)

--- a/src/services/small_webrtc_client.py
+++ b/src/services/small_webrtc_client.py
@@ -1,0 +1,269 @@
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+import numpy as np
+from pydantic import BaseModel
+
+from src.common.types import AudioCameraParams
+from src.services.webrtc_peer_connection import SmallWebRTCConnection, RawAudioTrack, RawVideoTrack
+from src.types.frames import (
+    UserAudioRawFrame,
+    UserImageRawFrame,
+    OutputAudioRawFrame,
+    OutputImageRawFrame,
+    TransportMessageFrame,
+)
+
+try:
+    import cv2
+    from aiortc import VideoStreamTrack
+    from aiortc.mediastreams import AudioStreamTrack, MediaStreamError
+    from av import AudioFrame, AudioResampler, VideoFrame
+except ModuleNotFoundError as e:
+    logging.error(f"Exception: {e}")
+    logging.error("In order to use the SmallWebRTC, you need to `pip install achatbot[webrtc]`.")
+    raise Exception(f"Missing module: {e}")
+
+
+class SmallWebRTCCallbacks(BaseModel):
+    on_app_message: Callable[[Any], Awaitable[None]]
+    on_client_connected: Callable[[SmallWebRTCConnection], Awaitable[None]]
+    on_client_disconnected: Callable[[SmallWebRTCConnection], Awaitable[None]]
+
+
+class SmallWebRTCClient:
+    FORMAT_CONVERSIONS = {
+        "yuv420p": cv2.COLOR_YUV2RGB_I420,
+        "yuvj420p": cv2.COLOR_YUV2RGB_I420,  # OpenCV treats both the same
+        "nv12": cv2.COLOR_YUV2RGB_NV12,
+        "gray": cv2.COLOR_GRAY2RGB,
+    }
+
+    def __init__(self, webrtc_connection: SmallWebRTCConnection, callbacks: SmallWebRTCCallbacks):
+        self._webrtc_connection = webrtc_connection
+        self._closing = False
+        self._callbacks = callbacks
+
+        self._audio_output_track = None
+        self._video_output_track = None
+        self._audio_input_track: Optional[AudioStreamTrack] = None
+        self._video_input_track: Optional[VideoStreamTrack] = None
+
+        self._params = None
+        self._audio_in_channels = None
+        self._in_sample_rate = None
+        self._out_sample_rate = None
+
+        # We are always resampling it for 16000 if the sample_rate that we receive is bigger than that.
+        # otherwise we face issues with Silero VAD
+        self._pipecat_resampler = AudioResampler("s16", "mono", 16000)
+
+        @self._webrtc_connection.event_handler("connected")
+        async def on_connected(connection: SmallWebRTCConnection):
+            logging.debug("Peer connection established.")
+            await self._handle_client_connected()
+
+        @self._webrtc_connection.event_handler("disconnected")
+        async def on_disconnected(connection: SmallWebRTCConnection):
+            logging.debug("Peer connection lost.")
+            await self._handle_peer_disconnected()
+
+        @self._webrtc_connection.event_handler("closed")
+        async def on_closed(connection: SmallWebRTCConnection):
+            logging.debug("Client connection closed.")
+            await self._handle_client_closed()
+
+        @self._webrtc_connection.event_handler("app-message")
+        async def on_app_message(connection: SmallWebRTCConnection, message: Any):
+            await self._handle_app_message(message)
+
+    def _convert_frame(self, frame_array: np.ndarray, format_name: str) -> np.ndarray:
+        """Convert a given frame to RGB format based on the input format.
+
+        Args:
+            frame_array (np.ndarray): The input frame.
+            format_name (str): The format of the input frame.
+
+        Returns:
+            np.ndarray: The converted RGB frame.
+
+        Raises:
+            ValueError: If the format is unsupported.
+        """
+        if format_name.startswith("rgb"):  # Already in RGB, no conversion needed
+            return frame_array
+
+        conversion_code = SmallWebRTCClient.FORMAT_CONVERSIONS.get(format_name)
+
+        if conversion_code is None:
+            raise ValueError(f"Unsupported format: {format_name}")
+
+        return cv2.cvtColor(frame_array, conversion_code)
+
+    async def read_video_frame(self):
+        """Reads a video frame from the given MediaStreamTrack, converts it to RGB,
+        and creates an UserImageRawFrame.
+        """
+        while True:
+            if self._video_input_track is None:
+                await asyncio.sleep(0.01)
+                continue
+
+            try:
+                frame = await asyncio.wait_for(self._video_input_track.recv(), timeout=2.0)
+            except asyncio.TimeoutError:
+                if self._webrtc_connection.is_connected():
+                    logging.warning("Timeout: No video frame received within the specified time.")
+                    # self._webrtc_connection.ask_to_renegotiate()
+                frame = None
+            except MediaStreamError:
+                logging.warning(
+                    "Received an unexpected media stream error while reading the audio."
+                )
+                frame = None
+
+            if frame is None or not isinstance(frame, VideoFrame):
+                # If no valid frame, sleep for a bit
+                await asyncio.sleep(0.01)
+                continue
+
+            format_name = frame.format.name
+            # Convert frame to NumPy array in its native format
+            frame_array = frame.to_ndarray(format=format_name)
+            frame_rgb = self._convert_frame(frame_array, format_name)
+
+            image_frame = UserImageRawFrame(
+                user_id=self._webrtc_connection.pc_id,
+                image=frame_rgb.tobytes(),
+                size=(frame.width, frame.height),
+                format="RGB",
+            )
+
+            yield image_frame
+
+    async def read_audio_frame(self):
+        """Reads 20ms of audio from the given MediaStreamTrack and creates an InputAudioRawFrame."""
+        while True:
+            if self._audio_input_track is None:
+                await asyncio.sleep(0.01)
+                continue
+
+            try:
+                frame = await asyncio.wait_for(self._audio_input_track.recv(), timeout=2.0)
+            except asyncio.TimeoutError:
+                if self._webrtc_connection.is_connected():
+                    logging.warning("Timeout: No audio frame received within the specified time.")
+                frame = None
+            except MediaStreamError:
+                logging.warning(
+                    "Received an unexpected media stream error while reading the audio."
+                )
+                frame = None
+
+            if frame is None or not isinstance(frame, AudioFrame):
+                # If we don't read any audio let's sleep for a little bit (i.e. busy wait).
+                await asyncio.sleep(0.01)
+                continue
+
+            if frame.sample_rate > self._in_sample_rate:
+                resampled_frames = self._pipecat_resampler.resample(frame)
+                for resampled_frame in resampled_frames:
+                    # 16-bit PCM bytes
+                    pcm_bytes = resampled_frame.to_ndarray().astype(np.int16).tobytes()
+                    audio_frame = UserAudioRawFrame(
+                        user_id=self._webrtc_connection.pc_id,
+                        audio=pcm_bytes,
+                        sample_rate=resampled_frame.sample_rate,
+                        num_channels=self._audio_in_channels,
+                    )
+                    yield audio_frame
+            else:
+                # 16-bit PCM bytes
+                pcm_bytes = frame.to_ndarray().astype(np.int16).tobytes()
+                audio_frame = UserAudioRawFrame(
+                    user_id=self._webrtc_connection.pc_id,
+                    audio=pcm_bytes,
+                    sample_rate=frame.sample_rate,
+                    num_channels=self._audio_in_channels,
+                )
+                yield audio_frame
+
+    async def write_audio_frame(self, frame: OutputAudioRawFrame):
+        if self._can_send() and self._audio_output_track:
+            await self._audio_output_track.add_audio_bytes(frame.audio)
+
+    async def write_video_frame(self, frame: OutputImageRawFrame):
+        if self._can_send() and self._video_output_track:
+            self._video_output_track.add_video_frame(frame)
+
+    async def setup(self, _params: AudioCameraParams, frame):
+        self._audio_in_channels = _params.audio_in_channels
+        self._in_sample_rate = _params.audio_in_sample_rate or frame.audio_in_sample_rate
+        self._out_sample_rate = _params.audio_out_sample_rate or frame.audio_out_sample_rate
+        self._params = _params
+
+    async def connect(self):
+        if self._webrtc_connection.is_connected():
+            # already initialized
+            return
+
+        logging.info(f"Connecting to Small WebRTC")
+        await self._webrtc_connection.connect()
+
+    async def disconnect(self):
+        if self.is_connected and not self.is_closing:
+            logging.info(f"Disconnecting to Small WebRTC")
+            self._closing = True
+            await self._webrtc_connection.disconnect()
+            await self._handle_peer_disconnected()
+
+    async def send_message(self, frame: TransportMessageFrame):
+        if self._can_send():
+            self._webrtc_connection.send_app_message(frame.message)
+
+    async def _handle_client_connected(self):
+        # There is nothing to do here yet, the pipeline is still not ready
+        if not self._params:
+            return
+
+        self._audio_input_track = self._webrtc_connection.audio_input_track()
+        self._video_input_track = self._webrtc_connection.video_input_track()
+        if self._params.audio_out_enabled:
+            self._audio_output_track = RawAudioTrack(sample_rate=self._out_sample_rate)
+            self._webrtc_connection.replace_audio_track(self._audio_output_track)
+
+        if self._params.video_out_enabled:
+            self._video_output_track = RawVideoTrack(
+                width=self._params.video_out_width, height=self._params.video_out_height
+            )
+            self._webrtc_connection.replace_video_track(self._video_output_track)
+
+        await self._callbacks.on_client_connected(self._webrtc_connection)
+
+    async def _handle_peer_disconnected(self):
+        self._audio_input_track = None
+        self._video_input_track = None
+        self._audio_output_track = None
+        self._video_output_track = None
+
+    async def _handle_client_closed(self):
+        self._audio_input_track = None
+        self._video_input_track = None
+        self._audio_output_track = None
+        self._video_output_track = None
+        await self._callbacks.on_client_disconnected(self._webrtc_connection)
+
+    async def _handle_app_message(self, message: Any):
+        await self._callbacks.on_app_message(message)
+
+    def _can_send(self):
+        return self.is_connected and not self.is_closing
+
+    @property
+    def is_connected(self) -> bool:
+        return self._webrtc_connection.is_connected()
+
+    @property
+    def is_closing(self) -> bool:
+        return self._closing

--- a/src/services/webrtc_peer_connection.py
+++ b/src/services/webrtc_peer_connection.py
@@ -1,0 +1,488 @@
+from collections import deque
+import fractions
+import time
+import asyncio
+import json
+import logging
+from typing import Any, List, Literal, Optional, Union
+
+from loguru import logger
+import numpy as np
+from pydantic import BaseModel, TypeAdapter
+
+from src.common.event import EventHandlerManager
+
+
+try:
+    from aiortc.rtcrtpreceiver import RemoteStreamTrack
+    from aiortc import (
+        AudioStreamTrack,
+        VideoStreamTrack,
+        MediaStreamTrack,
+        RTCConfiguration,
+        RTCIceServer,
+        RTCPeerConnection,
+        RTCSessionDescription,
+    )
+    from av import AudioFrame, VideoFrame
+    from av.frame import Frame
+except ModuleNotFoundError as e:
+    logging.error(f"Exception: {e}")
+    logging.error("In order to use the SmallWebRTC, you need to `pip install achatbot[webrtc]`.")
+    raise Exception(f"Missing module: {e}")
+
+SIGNALLING_TYPE = "signalling"
+AUDIO_TRANSCEIVER_INDEX = 0
+VIDEO_TRANSCEIVER_INDEX = 1
+
+
+class TrackStatusMessage(BaseModel):
+    type: Literal["trackStatus"]
+    receiver_index: int
+    enabled: bool
+
+
+class RenegotiateMessage(BaseModel):
+    type: Literal["renegotiate"] = "renegotiate"
+
+
+class PeerLeftMessage(BaseModel):
+    type: Literal["peerLeft"] = "peerLeft"
+
+
+class SignallingMessage:
+    Inbound = Union[TrackStatusMessage]  # in case we need to add new messages in the future
+    outbound = Union[RenegotiateMessage]
+
+
+class SmallWebRTCTrack:
+    def __init__(self, track: MediaStreamTrack):
+        self._track = track
+        self._enabled = True
+
+    def set_enabled(self, enabled: bool) -> None:
+        self._enabled = enabled
+
+    def is_enabled(self) -> bool:
+        return self._enabled
+
+    async def discard_old_frames(self):
+        remote_track = self._track
+        if isinstance(remote_track, RemoteStreamTrack):
+            if not hasattr(remote_track, "_queue") or not isinstance(
+                remote_track._queue, asyncio.Queue
+            ):
+                print("Warning: _queue does not exist or has changed in aiortc.")
+                return
+            logger.debug("Discarding old frames")
+            while not remote_track._queue.empty():
+                remote_track._queue.get_nowait()  # Remove the oldest frame
+                remote_track._queue.task_done()
+
+    async def recv(self) -> Optional[Frame]:
+        if not self._enabled:
+            return None
+        return await self._track.recv()
+
+    def __getattr__(self, name):
+        # Forward other attribute/method calls to the underlying track
+        return getattr(self._track, name)
+
+
+class RawAudioTrack(AudioStreamTrack):
+    def __init__(self, sample_rate):
+        super().__init__()
+        self._sample_rate = sample_rate
+        self._samples_per_10ms = sample_rate * 10 // 1000
+        self._bytes_per_10ms = self._samples_per_10ms * 2  # 16-bit (2 bytes per sample)
+        self._timestamp = 0
+        self._start = time.time()
+        # Queue of (bytes, future), broken into 10ms sub chunks as needed
+        self._chunk_queue = deque()
+
+    def add_audio_bytes(self, audio_bytes: bytes):
+        """Adds bytes to the audio buffer and returns a Future that completes when the data is processed."""
+        if len(audio_bytes) % self._bytes_per_10ms != 0:
+            raise ValueError("Audio bytes must be a multiple of 10ms size.")
+        future = asyncio.get_running_loop().create_future()
+
+        # Break input into 10ms chunks
+        for i in range(0, len(audio_bytes), self._bytes_per_10ms):
+            chunk = audio_bytes[i : i + self._bytes_per_10ms]
+            # Only the last chunk carries the future to be resolved once fully consumed
+            fut = future if i + self._bytes_per_10ms >= len(audio_bytes) else None
+            self._chunk_queue.append((chunk, fut))
+
+        return future
+
+    async def recv(self):
+        """Returns the next audio frame, generating silence if needed."""
+        # Compute required wait time for synchronization
+        if self._timestamp > 0:
+            wait = self._start + (self._timestamp / self._sample_rate) - time.time()
+            if wait > 0:
+                await asyncio.sleep(wait)
+
+        if self._chunk_queue:
+            chunk, future = self._chunk_queue.popleft()
+            if future and not future.done():
+                future.set_result(True)
+        else:
+            chunk = bytes(self._bytes_per_10ms)  # silence
+
+        # Convert the byte data to an ndarray of int16 samples
+        samples = np.frombuffer(chunk, dtype=np.int16)
+
+        # Create AudioFrame
+        frame = AudioFrame.from_ndarray(samples[None, :], layout="mono")
+        frame.sample_rate = self._sample_rate
+        frame.pts = self._timestamp
+        frame.time_base = fractions.Fraction(1, self._sample_rate)
+        self._timestamp += self._samples_per_10ms
+        return frame
+
+
+class RawVideoTrack(VideoStreamTrack):
+    def __init__(self, width, height):
+        super().__init__()
+        self._width = width
+        self._height = height
+        self._video_buffer = asyncio.Queue()
+
+    def add_video_frame(self, frame):
+        """Adds a raw video frame to the buffer."""
+        self._video_buffer.put_nowait(frame)
+
+    async def recv(self):
+        """Returns the next video frame, waiting if the buffer is empty."""
+        raw_frame = await self._video_buffer.get()
+
+        # Convert bytes to NumPy array
+        frame_data = np.frombuffer(raw_frame.image, dtype=np.uint8).reshape(
+            (self._height, self._width, 3)
+        )
+
+        frame = VideoFrame.from_ndarray(frame_data, format="rgb24")
+
+        # Assign timestamp
+        frame.pts, frame.time_base = await self.next_timestamp()
+
+        return frame
+
+
+# Alias so we don't need to expose RTCIceServer
+IceServer = RTCIceServer
+
+
+class SmallWebRTCConnection(EventHandlerManager):
+    def __init__(self, ice_servers: Optional[Union[List[str], List[IceServer]]] = None):
+        super().__init__()
+        if not ice_servers:
+            self.ice_servers: List[IceServer] = []
+        elif all(isinstance(s, IceServer) for s in ice_servers):
+            self.ice_servers = ice_servers
+        elif all(isinstance(s, str) for s in ice_servers):
+            self.ice_servers = [IceServer(urls=s) for s in ice_servers]
+        else:
+            raise TypeError("ice_servers must be either List[str] or List[RTCIceServer]")
+        self._connect_invoked = False
+        self._track_map = {}
+        self._track_getters = {
+            AUDIO_TRANSCEIVER_INDEX: self.audio_input_track,
+            VIDEO_TRANSCEIVER_INDEX: self.video_input_track,
+        }
+
+        self._initialize()
+
+        # Register supported handlers. The user will only be able to register
+        # these handlers.
+        self._register_event_handler("app-message")
+        self._register_event_handler("track-started")
+        self._register_event_handler("track-ended")
+        # connection states
+        self._register_event_handler("connecting")
+        self._register_event_handler("connected")
+        self._register_event_handler("disconnected")
+        self._register_event_handler("closed")
+        self._register_event_handler("failed")
+        self._register_event_handler("new")
+
+    @property
+    def pc(self) -> RTCPeerConnection:
+        return self._pc
+
+    @property
+    def pc_id(self) -> str:
+        return self._pc_id
+
+    def _initialize(self):
+        logger.debug("Initializing new peer connection")
+        rtc_config = RTCConfiguration(iceServers=self.ice_servers)
+
+        self._answer: Optional[RTCSessionDescription] = None
+        self._pc = RTCPeerConnection(rtc_config)
+        self._pc_id = self.name
+        self._setup_listeners()
+        self._data_channel = None
+        self._renegotiation_in_progress = False
+        self._last_received_time = None
+        self._message_queue = []
+        self._pending_app_messages = []
+
+    def _setup_listeners(self):
+        @self._pc.on("datachannel")
+        def on_datachannel(channel):
+            self._data_channel = channel
+
+            # Flush queued messages once the data channel is open
+            @channel.on("open")
+            async def on_open():
+                logger.debug("Data channel is open, flushing queued messages")
+                while self._message_queue:
+                    message = self._message_queue.pop(0)
+                    self._data_channel.send(message)
+
+            @channel.on("message")
+            async def on_message(message):
+                try:
+                    # aiortc does not provide any way so we can be aware when we are disconnected,
+                    # so we are using this keep alive message as a way to implement that
+                    if isinstance(message, str) and message.startswith("ping"):
+                        self._last_received_time = time.time()
+                    else:
+                        json_message = json.loads(message)
+                        if json_message["type"] == SIGNALLING_TYPE and json_message.get("message"):
+                            self._handle_signalling_message(json_message["message"])
+                        else:
+                            if self.is_connected():
+                                await self._call_event_handler("app-message", json_message)
+                            else:
+                                logger.debug("Client not connected. Queuing app-message.")
+                                self._pending_app_messages.append(json_message)
+                except Exception as e:
+                    logger.exception(f"Error parsing JSON message {message}, {e}")
+
+        # Despite the fact that aiortc provides this listener, they don't have a status for "disconnected"
+        # So, in case we loose connection, this event will not be triggered
+        @self._pc.on("connectionstatechange")
+        async def on_connectionstatechange():
+            await self._handle_new_connection_state()
+
+        # Despite the fact that aiortc provides this listener, they don't have a status for "disconnected"
+        # So, in case we loose connection, this event will not be triggered
+        @self._pc.on("iceconnectionstatechange")
+        async def on_iceconnectionstatechange():
+            logger.debug(
+                f"ICE connection state is {self._pc.iceConnectionState}, connection is {self._pc.connectionState}"
+            )
+
+        @self._pc.on("icegatheringstatechange")
+        async def on_icegatheringstatechange():
+            logger.debug(f"ICE gathering state is {self._pc.iceGatheringState}")
+
+        @self._pc.on("track")
+        async def on_track(track):
+            logger.debug(f"Track {track.kind} received")
+            await self._call_event_handler("track-started", track)
+
+            @track.on("ended")
+            async def on_ended():
+                logger.debug(f"Track {track.kind} ended")
+                await self._call_event_handler("track-ended", track)
+
+    async def _create_answer(self, sdp: str, type: str):
+        offer = RTCSessionDescription(sdp=sdp, type=type)
+        await self._pc.setRemoteDescription(offer)
+
+        # For some reason, aiortc is not respecting the SDP for the transceivers to be sendrcv
+        # so we are basically forcing it to act this way
+        self.force_transceivers_to_send_recv()
+
+        # this answer does not contain the ice candidates, which will be gathered later, after the setLocalDescription
+        logger.debug(f"Creating answer")
+        local_answer = await self._pc.createAnswer()
+        await self._pc.setLocalDescription(local_answer)
+        logger.debug(f"Setting the answer after the local description is created")
+        self._answer = self._pc.localDescription
+
+    async def initialize(self, sdp: str, type: str):
+        await self._create_answer(sdp, type)
+
+    async def connect(self):
+        self._connect_invoked = True
+        # If we already connected, trigger again the connected event
+        if self.is_connected():
+            await self._call_event_handler("connected")
+            logger.debug("Flushing pending app-messages")
+            for message in self._pending_app_messages:
+                await self._call_event_handler("app-message", message)
+            # We are renegotiating here, because likely we have loose the first video frames
+            # and aiortc does not handle that pretty well.
+            video_input_track = self.video_input_track()
+            if video_input_track:
+                await self.video_input_track().discard_old_frames()
+            self.ask_to_renegotiate()
+
+    async def renegotiate(self, sdp: str, type: str, restart_pc: bool = False):
+        logger.debug(f"Renegotiating {self._pc_id}")
+
+        if restart_pc:
+            await self._call_event_handler("disconnected")
+            logger.debug("Closing old peer connection")
+            # removing the listeners to prevent the bot from closing
+            self._pc.remove_all_listeners()
+            await self._close()
+            # we are initializing a new peer connection in this case.
+            self._initialize()
+
+        await self._create_answer(sdp, type)
+
+        # Maybe we should refactor to receive a message from the client side when the renegotiation is completed.
+        # or look at the peer connection listeners
+        # but this is good enough for now for testing.
+        async def delayed_task():
+            await asyncio.sleep(2)
+            self._renegotiation_in_progress = False
+
+        asyncio.create_task(delayed_task())
+
+    def force_transceivers_to_send_recv(self):
+        for transceiver in self._pc.getTransceivers():
+            transceiver.direction = "sendrecv"
+            # logger.debug(
+            #    f"Transceiver: {transceiver}, Mid: {transceiver.mid}, Direction: {transceiver.direction}"
+            # )
+            # logger.debug(f"Sender track: {transceiver.sender.track}")
+
+    def replace_audio_track(self, track):
+        logger.debug(f"Replacing audio track {track.kind}")
+        # Transceivers always appear in creation-order for both peers
+        # For now we are only considering that we are going to have 02 transceivers,
+        # one for audio and one for video
+        transceivers = self._pc.getTransceivers()
+        if len(transceivers) > 0 and transceivers[0].sender:
+            transceivers[0].sender.replaceTrack(track)
+        else:
+            logger.warning("Audio transceiver not found. Cannot replace audio track.")
+
+    def replace_video_track(self, track):
+        logger.debug(f"Replacing video track {track.kind}")
+        # Transceivers always appear in creation-order for both peers
+        # For now we are only considering that we are going to have 02 transceivers,
+        # one for audio and one for video
+        transceivers = self._pc.getTransceivers()
+        if len(transceivers) > 1 and transceivers[1].sender:
+            transceivers[1].sender.replaceTrack(track)
+        else:
+            logger.warning("Video transceiver not found. Cannot replace video track.")
+
+    async def disconnect(self):
+        self.send_app_message({"type": SIGNALLING_TYPE, "message": PeerLeftMessage().model_dump()})
+        await self._close()
+
+    async def _close(self):
+        if self._pc:
+            await self._pc.close()
+        self._message_queue.clear()
+        self._pending_app_messages.clear()
+        self._track_map = {}
+
+    def get_answer(self):
+        if not self._answer:
+            return None
+
+        return {
+            "sdp": self._answer.sdp,
+            "type": self._answer.type,
+            "pc_id": self._pc_id,
+        }
+
+    async def _handle_new_connection_state(self):
+        state = self._pc.connectionState
+        if state == "connected" and not self._connect_invoked:
+            # We are going to wait until the pipeline is ready before triggering the event
+            return
+        logger.debug(f"Connection state changed to: {state}")
+        await self._call_event_handler(state)
+        if state == "failed":
+            logger.warning("Connection failed, closing peer connection.")
+            await self._close()
+
+    # Despite the fact that aiortc provides this listener, they don't have a status for "disconnected"
+    # So, there is no advantage in looking at self._pc.connectionState
+    # That is why we are trying to keep our own state
+    def is_connected(self):
+        # If the small webrtc transport has never invoked to connect
+        # we are acting like if we are not connected
+        if not self._connect_invoked:
+            return False
+
+        if self._last_received_time is None:
+            # if we have never received a message, it is probably because the client has not created a data channel
+            # so we are going to trust aiortc in this case
+            return self._pc.connectionState == "connected"
+        # Checks if the last received ping was within the last 3 seconds.
+        return (time.time() - self._last_received_time) < 3
+
+    def audio_input_track(self):
+        if self._track_map.get(AUDIO_TRANSCEIVER_INDEX):
+            return self._track_map[AUDIO_TRANSCEIVER_INDEX]
+
+        # Transceivers always appear in creation-order for both peers
+        # For now we are only considering that we are going to have 02 transceivers,
+        # one for audio and one for video
+        transceivers = self._pc.getTransceivers()
+        if len(transceivers) == 0 or not transceivers[AUDIO_TRANSCEIVER_INDEX].receiver:
+            logger.warning("No audio transceiver is available")
+            return None
+
+        track = transceivers[AUDIO_TRANSCEIVER_INDEX].receiver.track
+        audio_track = SmallWebRTCTrack(track) if track else None
+        self._track_map[AUDIO_TRANSCEIVER_INDEX] = audio_track
+        return audio_track
+
+    def video_input_track(self):
+        if self._track_map.get(VIDEO_TRANSCEIVER_INDEX):
+            return self._track_map[VIDEO_TRANSCEIVER_INDEX]
+
+        # Transceivers always appear in creation-order for both peers
+        # For now we are only considering that we are going to have 02 transceivers,
+        # one for audio and one for video
+        transceivers = self._pc.getTransceivers()
+        if len(transceivers) <= 1 or not transceivers[VIDEO_TRANSCEIVER_INDEX].receiver:
+            logger.warning("No video transceiver is available")
+            return None
+
+        track = transceivers[VIDEO_TRANSCEIVER_INDEX].receiver.track
+        video_track = SmallWebRTCTrack(track) if track else None
+        self._track_map[VIDEO_TRANSCEIVER_INDEX] = video_track
+        return video_track
+
+    def send_app_message(self, message: Any):
+        json_message = json.dumps(message)
+        if self._data_channel and self._data_channel.readyState == "open":
+            self._data_channel.send(json_message)
+        else:
+            logger.debug("Data channel not ready, queuing message")
+            self._message_queue.append(json_message)
+
+    def ask_to_renegotiate(self):
+        if self._renegotiation_in_progress:
+            return
+
+        self._renegotiation_in_progress = True
+        self.send_app_message(
+            {"type": SIGNALLING_TYPE, "message": RenegotiateMessage().model_dump()}
+        )
+
+    def _handle_signalling_message(self, message):
+        logger.debug(f"Signalling message received: {message}")
+        inbound_adapter = TypeAdapter(SignallingMessage.Inbound)
+        signalling_message = inbound_adapter.validate_python(message)
+        match signalling_message:
+            case TrackStatusMessage():
+                track = (
+                    self._track_getters.get(signalling_message.receiver_index) or (lambda: None)
+                )()
+                if track:
+                    track.set_enabled(signalling_message.enabled)

--- a/src/transports/small_webrtc.py
+++ b/src/transports/small_webrtc.py
@@ -1,0 +1,74 @@
+import logging
+from typing import Any, Optional
+
+from apipeline.processors.frame_processor import FrameDirection
+
+from src.processors.small_webrtc_input_transport_processor import SmallWebRTCInputProcessor
+from src.processors.small_webrtc_output_transport_processor import SmallWebRTCOutputProcessor
+from src.services.small_webrtc_client import SmallWebRTCCallbacks, SmallWebRTCClient
+from src.common.types import AudioCameraParams
+from src.services.webrtc_peer_connection import SmallWebRTCConnection
+from src.transports.base import BaseTransport
+from src.types.frames import SpriteFrame, OutputAudioRawFrame, OutputImageRawFrame
+
+
+class SmallWebRTCTransport(BaseTransport):
+    def __init__(
+        self,
+        webrtc_connection: SmallWebRTCConnection,
+        params: AudioCameraParams,
+        input_name: Optional[str] = None,
+        output_name: Optional[str] = None,
+    ):
+        super().__init__(input_name=input_name, output_name=output_name)
+        self._params = params
+
+        self._callbacks = SmallWebRTCCallbacks(
+            on_app_message=self._on_app_message,
+            on_client_connected=self._on_client_connected,
+            on_client_disconnected=self._on_client_disconnected,
+        )
+
+        self._client = SmallWebRTCClient(webrtc_connection, self._callbacks)
+
+        self._input: Optional[SmallWebRTCInputProcessor] = None
+        self._output: Optional[SmallWebRTCOutputProcessor] = None
+
+        # Register supported handlers. The user will only be able to register
+        # these handlers.
+        self._register_event_handler("on_app_message")
+        self._register_event_handler("on_client_connected")
+        self._register_event_handler("on_client_disconnected")
+
+    def input(self) -> SmallWebRTCInputProcessor:
+        if not self._input:
+            self._input = SmallWebRTCInputProcessor(
+                self._client, self._params, name=self._input_name
+            )
+        return self._input
+
+    def output(self) -> SmallWebRTCOutputProcessor:
+        if not self._output:
+            self._output = SmallWebRTCOutputProcessor(
+                self._client, self._params, name=self._input_name
+            )
+        return self._output
+
+    async def send_image(self, frame: OutputImageRawFrame | SpriteFrame):
+        if self._output:
+            await self._output.queue_frame(frame, FrameDirection.DOWNSTREAM)
+
+    async def send_audio(self, frame: OutputAudioRawFrame):
+        if self._output:
+            await self._output.queue_frame(frame, FrameDirection.DOWNSTREAM)
+
+    async def _on_app_message(self, message: Any):
+        if self._input:
+            await self._input.push_app_message(message)
+        await self._call_event_handler("on_app_message", message)
+
+    async def _on_client_connected(self, webrtc_connection):
+        await self._call_event_handler("on_client_connected", webrtc_connection)
+
+    async def _on_client_disconnected(self, webrtc_connection):
+        await self._call_event_handler("on_client_disconnected", webrtc_connection)

--- a/src/types/frames/data_frames.py
+++ b/src/types/frames/data_frames.py
@@ -6,6 +6,20 @@ from apipeline.frames.data_frames import Frame, DataFrame, TextFrame, ImageRawFr
 
 
 @dataclass
+class InputImageRawFrame(ImageRawFrame):
+    """
+    input image frame
+    """
+
+
+@dataclass
+class OutputImageRawFrame(ImageRawFrame):
+    """
+    output image frame
+    """
+
+
+@dataclass
 class URLImageRawFrame(ImageRawFrame):
     """An image with an associated URL. Will be shown by the transport if the
     transport's camera is enabled.
@@ -175,6 +189,16 @@ class FunctionCallResultFrame(DataFrame):
     tool_call_id: str
     arguments: dict
     result: Any
+
+
+@dataclass
+class InputAudioRawFrame(AudioRawFrame):
+    """Input audio frame"""
+
+
+@dataclass
+class OutputAudioRawFrame(AudioRawFrame):
+    """output audio frame"""
 
 
 @dataclass


### PR DESCRIPTION
- add SmallWebRTCTransport and SmallWebRTCConnection(peer)
- add SmallWebrtcBot
- add signaling_bot_server to run webrtc signaling bot with fastapi (http)
- use lifespan to init load model before run app and clear after run